### PR TITLE
Remove pre-loaded dustmaps

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,11 +63,11 @@ jobs:
         run: |
           pip install numpy
           pip install tox
-      - name: Run tests with TRILEGAL download
+      - name: Run tests with remote
         run: |
           mkdir ./.tmp
           mkdir ./.tmp/${{ matrix. toxenv }}
-          tox -e ${{ matrix.toxenv }} -- --trilegal_download
+          tox -e ${{ matrix.toxenv }} -- --remote-data
       - name: Run documentation
         run: tox -e build_docs
       - name: Upload coverage to codecov

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,11 +63,11 @@ jobs:
         run: |
           pip install numpy
           pip install tox
-      - name: Run tests with remote
+      - name: Run tests with TRILEGAL download
         run: |
           mkdir ./.tmp
           mkdir ./.tmp/${{ matrix. toxenv }}
-          tox -e ${{ matrix.toxenv }} -- --remote-data
+          tox -e ${{ matrix.toxenv }} -- --trilegal_download
       - name: Run documentation
         run: tox -e build_docs
       - name: Upload coverage to codecov

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -26,6 +26,12 @@ jobs:
       uses: docker/setup-qemu-action@v2
       with:
         platforms: all
+    # Doesn't really install anything - just links gfortran to the right path
+    - uses: fortran-lang/setup-fortran@v1
+      id: setup-fortran
+      with:
+        compiler: gcc
+        version: 11
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.16.2
       env:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -26,9 +26,6 @@ jobs:
       uses: docker/setup-qemu-action@v2
       with:
         platforms: all
-    # Doesn't really install anything - just links gfortran to the right path
-    - name: Setup GNU Fortran
-      uses: modflowpy/install-gfortran-action@v1
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.16.2
       env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,13 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Removed hard-coded SFD dustmaps, using the ``dustmaps`` package to manage the
+  dataset instead. [#69]
+
 Other Changes
 ^^^^^^^^^^^^^
+
+- Added ``dustmaps`` as a dependency. [#69]
 
 
 0.1.2 (2023-10-27)

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -96,6 +96,9 @@ Boolean determining whether to run the final stage of the cross-match process, i
 
 Flag for whether to include the simulated effects of blended sources on the measured astrometry in the two catalogues or not.
 
+.. note::
+    If ``include_perturb_auf`` is ``True`` then ``dustmaps`` will be called to obtain line-of-sight extinction values. You will need the SFD dustmaps to be pre-downloaded; to do so before you call the cross-match procedure you must run ``dustmaps.sfd.fetch()``; see the ``dustmaps`` documentation for more details on how to specific a particular download location.
+
 ``include_phot_like``
 
 Flag for the inclusion of the likelihood of match or non-match based on the photometric information in the two catalogues.
@@ -186,7 +189,7 @@ These parameters are required in two separate files, one per catalogue to be cro
 
 These can be divided into those inputs that are always required:
 
-``cat_folder_path``, ``cat_name``, ``filt_names``, ``auf_folder_path``, ``auf_region_type``, ``auf_region_frame``, ``auf_region_points``, and ``correct_astrometry``;
+``cat_folder_path``, ``cat_name``, ``filt_names``, ``auf_folder_path``, ``auf_region_type``, ``auf_region_frame``, ``auf_region_points``, ``correct_astrometry``, and ``compute_snr_mag_relation``;
 
 those that are only required if the `Joint Parameters`_ option ``include_perturb_auf`` is ``True``:
 
@@ -260,6 +263,13 @@ Based on ``auf_region_type``, this must either by six space-separated floats, co
 ``correct_astrometry``
 
 In cases where catalogues have unreliable *centroid* uncertainties, before catalogue matching occurs the dataset can be fit for systematic corrections to its quoted astrometric precisions through ensemble match separation distance distributions to a higher-precision dataset (see the :doc:`Processing<pre_post_process>` section). This flag controls whether this is performed on a chunk-by-chunk basis during the initialisation step of ``CrossMatch``.
+
+.. note::
+    If ``correct_astrometry`` is ``True`` then ``dustmaps`` will be called to obtain line-of-sight extinction values. You will need the SFD dustmaps to be pre-downloaded; to do so before you call the cross-match procedure you must run ``dustmaps.sfd.fetch()``; see the ``dustmaps`` documentation for more details on how to specific a particular download location.
+
+``compute_snr_mag_relation``
+
+This flag can be ``False`` if the relationship between signal-to-noise ratio and magnitude is pre-computed; otherwise it indicates that the functional form of SNR vs brightness should be derived for the particular catalogue in question.
 
 ``fit_gal_flag``
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,6 +16,7 @@ The current package requirements are:
 * ``skypy``
 * ``speclite``
 * ``pandas``
+* ``dustmaps``
 * ``scikit-build-core``
 * ``cmake``
 
@@ -44,7 +45,7 @@ As of now, the only way to install this package is by downloading it from the `G
 
 Once you have installed your choice of conda, then you can create an initial conda environment::
 
-    conda create -n your_environment_name -c conda-forge python=3.9 numpy scipy astropy matplotlib skypy speclite pandas scikit-build-core cmake
+    conda create -n your_environment_name -c conda-forge python=3.9 numpy scipy astropy matplotlib skypy speclite pandas dustmaps scikit-build-core cmake
 
 although you can drop the ``=3.9``, or chose another (later) Python version -- remembering the minimum version is 3.8 -- if you desire to do so. Then activate this as our Python environment::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,22 +7,22 @@ Package Requirements
 
 Currently there are no strict criteria for installation; it is suggested that you use the most up-to-date package versions available. The one exception there is that the minimum version of Python is set to 3.8, and development is currently focused on Python 3.9+.
 
-The current package requirements are:
+The current package requirements, and citations to give for use of ``macauff`` in your work where available, are:
 
-* ``numpy``
-* ``scipy``
-* ``astropy``
-* ``matplotlib``
-* ``skypy``
-* ``speclite``
-* ``pandas``
-* ``dustmaps``
-* ``scikit-build-core``
+* ``numpy`` -- Harris et al. 2020 (Nature, 585, 357)
+* ``scipy`` -- Virtanen et al. 2020 (Nature Methods, 17, 261)
+* ``astropy`` -- Astropy Collaboration et al. 2013 (A&A, 558, 33); Astropy Collaboration et al. 2018 (ApJ, 156, 123); Astropy Collaboration et al. 2022 (ApJ, 935, 167)
+* ``matplotlib`` -- Hunter 2007 (Computing in Science & Engineering, 9, 90)
+* ``skypy`` -- Amara et al. 2021 (JOSS, 6, 3056)
+* ``speclite`` -- Kirkby et al. 2023 (doi.org/10.5281/zenodo.7734526)
+* ``pandas`` -- The pandas development team 2020 (doi.org/10.5281/zenodo.3509134)
+* ``dustmaps`` -- Schlafly & Finkbeiner 2011 (ApJ, 737, 103); Schlegel, Finkbeiner & Davis 1998 (ApJ, 500, 525; doi 10.7910/DVN/EWCNL5); Green 2018 (JOSS, 3, 695)
+* ``scikit-build-core`` -- Schreiner et al. 2022 (doi.org/10.25080/majora-212e5952-033)
 * ``cmake``
 
 with an optional dependency of
 
-* ``mpi4py``.
+* ``mpi4py`` -- Dalcin, Paz, & Storti 2005 (Journal of Parallel and Distributed Computing, 65, 1108); Dalcin & Fang 2021 (Computing in Science & Engineering, 23, 47).
 
 For running the test suite the requirements are:
 

--- a/macauff/get_trilegal_wrapper.py
+++ b/macauff/get_trilegal_wrapper.py
@@ -29,6 +29,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from scipy.interpolate import RegularGridInterpolator
 import numpy as np
+import dustmaps.sfd
 
 
 __all__ = []
@@ -245,63 +246,10 @@ def get_AV_infinity(ra, dec, frame='icrs'):
     """
     coords = SkyCoord(ra, dec, unit='deg', frame=frame).transform_to('galactic')
 
-    l = coords.l.degree
-    b = coords.b.degree
-
-    ebv = sfd_ebv.get_sfd_ebv(l, b)
-    AV = 2.742 * ebv
+    # Load the necessary dust maps from Schlegel, Finkbeiner & Davis 1998
+    # (ApJ, 500, 525) to extract E(B-V) at infinity.
+    dustmaps.sfd.fetch()
+    sfd_ebv = dustmaps.sfd.SFDQuery()
+    AV = 2.742 * sfd_ebv(coords)
 
     return AV
-
-
-class SFDEBV:
-    def __init__(self):
-        """
-        Load the necessary dust maps from Schlegel, Finkbeiner & Davis 1998
-        (ApJ, 500, 525) to extract E(B-V) at infinity.
-        """
-        data_ngp = fits.open(os.path.join(os.path.dirname(__file__),
-                                          'tests/data/SFD_dust_4096_ngp.fits'))[0].data
-        data_sgp = fits.open(os.path.join(os.path.dirname(__file__),
-                                          'tests/data/SFD_dust_4096_sgp.fits'))[0].data
-
-        xs, ys = np.meshgrid(np.arange(4096), np.arange(4096), indexing='ij', sparse=True)
-        self.f_interp_ngp = RegularGridInterpolator((np.arange(4096), np.arange(4096)), data_ngp,
-                                                    bounds_error=False, fill_value=None)
-        self.f_interp_sgp = RegularGridInterpolator((np.arange(4096), np.arange(4096)), data_sgp,
-                                                    bounds_error=False, fill_value=None)
-        self.n_ngp = 1
-        self.n_sgp = -1
-
-    def get_sfd_ebv(self, l, b):
-        """
-        Interpolate the grid of SFD dust maps to the desired coordinates.
-
-        Parameters
-        ----------
-        l : float or list or numpy.ndarray of floats
-            The Galactic longitudes of the places to evaluate extinction.
-        b : float or list or numpy.ndarray of floats
-            Galatic latitudes to evaluate E(B-V) at.
-
-        Returns
-        ebv : numpy.ndarray of floats
-            E(B-V) at each ``l``-``b`` pair.
-        """
-        l, b = np.atleast_1d(l), np.atleast_1d(b)
-        if np.all(l.shape == b.shape) and len(l.shape) > 1:
-            l, b = l.flatten(), b.flatten()
-        ebv = np.empty(len(l), float)
-        for q, n, f in zip([b >= 0, b < 0], [self.n_ngp, self.n_sgp],
-                           [self.f_interp_ngp, self.f_interp_sgp]):
-            if np.sum(q) > 0:
-                x = (2048 * np.sqrt(1 - n * np.sin(np.radians(b[q]))) *
-                     np.cos(np.radians(l[q])) + 2047.5)
-                y = (-2048 * n * np.sqrt(1 - n * np.sin(np.radians(b[q]))) *
-                     np.sin(np.radians(l[q])) + 2047.5)
-
-                ebv[q] = f(np.array([y, x]).T)
-        return ebv
-
-
-sfd_ebv = SFDEBV()

--- a/macauff/get_trilegal_wrapper.py
+++ b/macauff/get_trilegal_wrapper.py
@@ -26,8 +26,6 @@ import time
 
 from astropy.units import UnitsError
 from astropy.coordinates import SkyCoord
-from astropy.io import fits
-from scipy.interpolate import RegularGridInterpolator
 import numpy as np
 import dustmaps.sfd
 
@@ -226,8 +224,9 @@ def trilegal_webcall(trilegal_version, l, b, area, binaries, AV, sigma_AV, filte
 
 def get_AV_infinity(ra, dec, frame='icrs'):
     """
-    Gets the A_V exctinction at infinity for a given line of sight, using the
-    updated parameters from Schlafly & Finkbeiner 2011 (ApJ 737, 103), table 6.
+    Gets the Schlegel, Finkbeiner & Davis 1998 (ApJ, 500, 525) A_V extinction
+    at infinity for a given line of sight, using the updated parameters from
+    Schlafly & Finkbeiner 2011 (ApJ 737, 103), table 6.
 
     Parameters
     ----------
@@ -248,9 +247,6 @@ def get_AV_infinity(ra, dec, frame='icrs'):
     dec = np.atleast_1d(dec)
     coords = SkyCoord(ra, dec, unit='deg', frame=frame).transform_to('galactic')
 
-    # Load the necessary dust maps from Schlegel, Finkbeiner & Davis 1998
-    # (ApJ, 500, 525) to extract E(B-V) at infinity.
-    dustmaps.sfd.fetch()
     sfd_ebv = dustmaps.sfd.SFDQuery()
     AV = 2.742 * sfd_ebv(coords)
 

--- a/macauff/get_trilegal_wrapper.py
+++ b/macauff/get_trilegal_wrapper.py
@@ -184,7 +184,7 @@ def trilegal_webcall(trilegal_version, l, b, area, binaries, AV, sigma_AV, filte
         else:
             print("No communication with {}, will retry in 2 min".format(webserver))
             time.sleep(120)
-            return "timeout"
+            return "nocomm"
         if not notconnected:
             with open('{}/tmpfile'.format(outfolder), 'r') as f:
                 lines = f.readlines()
@@ -231,19 +231,21 @@ def get_AV_infinity(ra, dec, frame='icrs'):
 
     Parameters
     ----------
-    ra : float
+    ra : float, list, or numpy.ndarray
         Sky coordinate.
-    dec : float
+    dec : float, list, or numpy.ndarray
         Sky coordinate.
     frame : string, optional
         Frame of input coordinates (e.g., ``'icrs', 'galactic'``)
 
     Returns
     -------
-    AV : float
+    AV : numpy.ndarray
         Extinction at infinity as given by the SFD dust maps for the chosen sky
         coordinates.
     """
+    ra = np.atleast_1d(ra)
+    dec = np.atleast_1d(dec)
     coords = SkyCoord(ra, dec, unit='deg', frame=frame).transform_to('galactic')
 
     # Load the necessary dust maps from Schlegel, Finkbeiner & Davis 1998

--- a/macauff/tests/test_fit_astrometry.py
+++ b/macauff/tests/test_fit_astrometry.py
@@ -216,6 +216,7 @@ class TestAstroCorrection:
             ac(self.a_cat_name, self.b_cat_name, a_cat_func, b_cat_func,
                tri_download=False, make_plots=True, make_summary_plot=True)
 
+    @pytest.mark.remote_data
     @pytest.mark.parametrize("npy_or_csv,coord_or_chunk,coord_system,pregenerate_cutouts",
                              [("csv", "chunk", "equatorial", True),
                               ("npy", "coord", "galactic", False),

--- a/macauff/tests/test_get_trilegal_wrapper.py
+++ b/macauff/tests/test_get_trilegal_wrapper.py
@@ -3,11 +3,13 @@
 Tests for the "get_trilegal_wrapper" module.
 '''
 
+import pytest
 from numpy.testing import assert_allclose
 
 from ..get_trilegal_wrapper import get_AV_infinity
 
 
+@pytest.mark.remote_data
 def test_get_av_infinity():
     for l, b, check_av in zip([10, 312, 48, 96], [4, 1, -30, -78], [2.793, 11.046, 0.198, 0.058]):
         assert_allclose(check_av, get_AV_infinity(l, b, frame='galactic'), atol=1e-3)

--- a/macauff/tests/test_get_trilegal_wrapper.py
+++ b/macauff/tests/test_get_trilegal_wrapper.py
@@ -13,3 +13,7 @@ from ..get_trilegal_wrapper import get_AV_infinity
 def test_get_av_infinity():
     for l, b, check_av in zip([10, 312, 48, 96], [4, 1, -30, -78], [2.793, 11.046, 0.198, 0.058]):
         assert_allclose(check_av, get_AV_infinity(l, b, frame='galactic'), atol=1e-3)
+
+    assert_allclose([2.793, 11.046, 0.198, 0.058],
+                    get_AV_infinity([10, 312, 48, 96], [4, 1, -30, -78], frame='galactic'),
+                    atol=1e-3)

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -1313,6 +1313,7 @@ class TestInputs:
                     os.path.join(os.path.dirname(__file__), 'data/cat_a_params_2.txt'),
                     os.path.join(os.path.dirname(__file__), 'data/cat_b_params_.txt'))
 
+    @pytest.mark.remote_data
     def test_crossmatch_correct_astrometry_inputs(self):
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -653,6 +653,7 @@ class TestMakePerturbAUFs():
                               z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, alpha0=1,
                               alpha1=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1)
 
+    @pytest.mark.remote_data
     def test_without_compute_local_density(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.
@@ -771,6 +772,7 @@ class TestMakePerturbAUFs():
 
         assert_allclose(fake_fourier, track_fourier, rtol=0.05)
 
+    @pytest.mark.remote_data
     def test_create_single_low_numbers(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.
@@ -828,6 +830,7 @@ class TestMakePerturbAUFs():
                 compute_local_density=False, fit_gal_flag=False, run_fw=True, run_psf=False,
                 snr_mag_params=snr_mag_params, al_avs=[0])
 
+    @pytest.mark.remote_data
     def test_psf_algorithm_without_compute_local_density(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.
@@ -951,6 +954,7 @@ class TestMakePerturbAUFs():
                 assert_allclose(keep_flux[0], (prob_0_draw*0 + prob_1_draw*df +
                                 prob_2_draw*2*df), rtol=0.1, atol=0.005)
 
+    @pytest.mark.remote_data
     def test_with_compute_local_density(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.
@@ -1129,6 +1133,7 @@ class TestMakePerturbAUFs():
 
         assert_allclose(fake_fourier, fourier[:, 0], rtol=0.05)
 
+    @pytest.mark.remote_data
     def test_with_galaxy_counts(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.
@@ -1432,6 +1437,7 @@ def test_make_tri_counts(run_type):
                 use_bright=True, use_faint=False, al_av=0.9, av_grid=np.array([2, 2, 2, 2]))
 
 
+@pytest.mark.trilegal_download
 @pytest.mark.remote_data
 def test_trilegal_download():
     tri_folder = '.'

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -1437,7 +1437,6 @@ def test_make_tri_counts(run_type):
                 use_bright=True, use_faint=False, al_av=0.9, av_grid=np.array([2, 2, 2, 2]))
 
 
-@pytest.mark.trilegal_download
 @pytest.mark.remote_data
 def test_trilegal_download():
     tri_folder = '.'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "matplotlib",
     # We need to build a binary compatible with numpy 1.21
     "numpy>=1.21",
+    "scipy",
     "pandas",
     "skypy",
     "speclite",
@@ -28,7 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest-astropy",
-    "scipy",
+    "pytest-timeout",
 ]
 docs = [
     "sphinx-astropy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest-astropy",
-    "pytest-timeout",
 ]
 docs = [
     "sphinx-astropy",
@@ -43,6 +42,3 @@ skip = [
     "*musl*",  # we don't support MUSL Linux
     "pp*",  # we don't support PyPy
 ]
-
-[tool.pytest.ini_options]
-markers = ["trilegal_download"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,6 @@ skip = [
     "*musl*",  # we don't support MUSL Linux
     "pp*",  # we don't support PyPy
 ]
+
+[tool.pytest.ini_options]
+markers = ["trilegal_download"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pandas",
     "skypy",
     "speclite",
+    "dustmaps",
 ]
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,10 @@ envlist =
 	py{38,39,310,311}-test{,-cov}
 	build_docs
 
-isolated_build = true
-
-install_command = python -I -m pip {opts} {packages} --config-settings=cmake.build-type="Debug"
-
 [testenv]
 changedir = .tmp/{envname}
+
+install_command = python -I -m pip install {opts} {packages} --config-settings=cmake.build-type="Debug"
 
 deps =
 	pytest

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ extras =
 	build_docs: docs
 
 commands =
+    python -c "import dustmaps.sfd; dustmaps.sfd.fetch()"
     !cov: pytest --pyargs macauff {posargs}
     cov: pytest --pyargs macauff --cov macauff {posargs} --cov-config={toxinidir}/tox.ini
     cov: coverage xml -o {toxworkdir}/coverage.xml


### PR DESCRIPTION
I did not catch the issue with wheels and saving pre-generated SFD dustmaps into the `test/data` folder, which causes the compiled files to be unnecessarily large, as per #68 

Implementation of `dustmaps` to download the datasets outside of the software package, which closes #68.

Additionally, in a common fashion as the `dustmaps` download calls, added full-timeout error raising for TRILEGAL calls, in cases where the server is unresponsive or unavailable.