### PR TITLE
Remove memmap configuration option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,15 @@ Bug Fixes
 API Changes
 ^^^^^^^^^^^
 
+- Removed ``use_memmap_files`` as an input into ``CrossMatch``, along with
+  ``run_auf``, ``run_group``, ``run_cf``, and ``run_source`` from parameters
+  input into the cross-match process. This means that there is no option to
+  run larger matches by slicing one large input catalogue file, and runs should
+  be broken into smaller runs to be parallelised via chunking instead. [#71]
+
+- Removed ``mem_chunk_num`` as input configuration parameter, dealing with the
+  entire catalogue match in memory in one go. [#71]
+
 - Removed hard-coded SFD dustmaps, using the ``dustmaps`` package to manage the
   dataset instead. [#69]
 

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -32,8 +32,6 @@ As well as the parameters required that are ingested through the input parameter
 
 - ``chunks_folder_path``: the directory in which the folders containing parameters files are stored
 
-- ``use_memmap_files``: a boolean flag indicating whether or not to save temporary, intermediate arrays to disk and load variables through memmapping. Should be used if the catalogue regions being matched are sufficiently large that they cannot be stored in memory at once. Alternatively, consider smaller chunks. Optional, defaulting to ``False``.
-
 - ``use_mpi``: boolean flag for whether to parallelise distribution of chunks using MPI. If ``False`` chunks will be run in serial; defaults to ``True``, but with a fallback for if the appropriate module is not available.
 
 If you do not want to (or cannot) use MPI to distribute larger cross-match runs, with numerous chunks that will take significant compute time to run, then the first two inputs, combined with with ``use_mpi=False``, are all you need to consider. However, if you wish to use MPI then the remaining keyword arguments control its use:
@@ -53,7 +51,7 @@ These parameters are only provided in the single, common-parameter input file, a
 
 There are some parameters that must be given in all runs:
 
-``joint_folder_path``, ``run_auf``, ``run_group``, ``run_cf``, ``run_source``, ``include_perturb_auf``, ``include_phot_like``, ``use_phot_priors``, ``cross_match_extent``, ``mem_chunk_num``, ``pos_corr_dist``, ``cf_region_type``, ``cf_region_frame``, ``cf_region_points``, ``real_hankel_points``, ``four_hankel_points``, ``four_max_rho``, ``int_fracs``, ``make_output_csv``, and ``n_pool``;
+``joint_folder_path``, ``include_perturb_auf``, ``include_phot_like``, ``use_phot_priors``, ``cross_match_extent``, ``mem_chunk_num``, ``pos_corr_dist``, ``cf_region_type``, ``cf_region_frame``, ``cf_region_points``, ``real_hankel_points``, ``four_hankel_points``, ``four_max_rho``, ``int_fracs``, ``make_output_csv``, and ``n_pool``;
 
 options which need to be supplied if ``make_output_csv`` is ``True``:
 
@@ -72,25 +70,6 @@ Common Parameter Description
 ``joint_folder_path``
 
 The top-level folder location, into which all intermediate files and folders are placed, when created during the cross-match process. This can either be an absolute file path, or relative to the folder from which your script that called `CrossMatch()` is based.
-
-.. note::
-    The four ``run_`` parameters below are called in order. If an earlier stage flag is set to ``True``, an error will be raised in a subsequent flag is set to ``False``.
-
-``run_auf``
-
-Flag to determine if the AUF simulation stage of the cross-match process should be run, or if previously generated files should be used when present.
-
-``run_group``
-
-Flag dictating whether the source grouping -- and island creation -- stage of the process is run, or if previously created islands of sources should be used for this match.
-
-``run_cf``
-
-Flag controlling whether or not to calculate the photometric likelihood information, as determined by ``include_phot_like`` and ``use_phot_priors``, for this cross-match.
-
-``run_source``
-
-Boolean determining whether to run the final stage of the cross-match process, in which posterior probabilities of matches and non-matches for each island of sources are calculated.
 
 ``include_perturb_auf``
 

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -51,7 +51,7 @@ These parameters are only provided in the single, common-parameter input file, a
 
 There are some parameters that must be given in all runs:
 
-``joint_folder_path``, ``include_perturb_auf``, ``include_phot_like``, ``use_phot_priors``, ``cross_match_extent``, ``mem_chunk_num``, ``pos_corr_dist``, ``cf_region_type``, ``cf_region_frame``, ``cf_region_points``, ``real_hankel_points``, ``four_hankel_points``, ``four_max_rho``, ``int_fracs``, ``make_output_csv``, and ``n_pool``;
+``joint_folder_path``, ``include_perturb_auf``, ``include_phot_like``, ``use_phot_priors``, ``cross_match_extent``, ``pos_corr_dist``, ``cf_region_type``, ``cf_region_frame``, ``cf_region_points``, ``real_hankel_points``, ``four_hankel_points``, ``four_max_rho``, ``int_fracs``, ``make_output_csv``, and ``n_pool``;
 
 options which need to be supplied if ``make_output_csv`` is ``True``:
 
@@ -92,10 +92,6 @@ The maximum extent of the matching process. When not matching all-sky catalogues
 
 .. note::
     In cases where the boundary defining the cross-match overlaps the 0-360 boundary of the given coordinate system, the longitudes should be given relative to 0 degrees. For example, if we had a boundary that ran from 350 degrees up to 360 (0) degrees, and on to 10 degrees, ``cross_match_extent`` would have for its input longitudes ``-10 10``. Internally the software is able to handle the boundary for source coordinates, but requires the extents to be correctly input for these regions.
-
-``mem_chunk_num``
-
-The number of smaller subsets into which to break various loops throughout the cross-match process. Used to reduce the memory usage of the process at any given time, in case of catalogues too large to fit into memory at once.
 
 ``pos_corr_dist``
 

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -59,7 +59,7 @@ options which need to be supplied if ``make_output_csv`` is ``True``:
 
 and those options which only need to be supplied if ``include_perturb_auf`` is ``True``:
 
-``num_trials``, ``compute_local_density``, and ``d_mag``.
+``num_trials``, and ``d_mag``.
 
 .. note::
     ``num_trials`` and ``d_mag`` currently need to be supplied if either ``correct_astrometry`` option in the two `Catalogue-specific Parameters`_ config files is ``True`` as well.
@@ -152,10 +152,6 @@ Filename to save out the respective non-match catalogue objects and metadata to.
 
 The number of PSF realisations to draw when simulating the perturbation component of the AUF. Should be an integer. Only required if ``include_perturb_auf`` is ``True``.
 
-``compute_local_density``
-
-Boolean flag, ``yes`` or ``no``, to indicate whether to on-the-fly compute the local densities of sources in each catalogue for use in its perturbation AUF component, or to use pre-computed values. ``yes`` indicates values will be computed during the cross-match process. Only required if ``include_perturb_auf`` is ``True``.
-
 ``d_mag``
 
 Bin sizes for magnitudes used to represent the source number density used in the random drawing of perturbation AUF component PSFs. Should be a single float. Only required if ``include_perturb_auf`` is ``True``.
@@ -172,15 +168,11 @@ These can be divided into those inputs that are always required:
 
 those that are only required if the `Joint Parameters`_ option ``include_perturb_auf`` is ``True``:
 
-``fit_gal_flag``, ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, and ``gal_al_avs``;
+``fit_gal_flag``, ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``gal_al_avs``, and ``dens_dist``;
 
 parameters required if ``run_psf_auf`` is ``True``:
 
 ``dd_params_path`` and ``l_cut_path``;
-
-the parameter needed if `Joint Parameters`_ option ``compute_local_density`` is ``True`` (and hence ``include_perturb_auf`` is ``True``):
-
-``dens_dist``;
 
 the inputs required in each catalogue parameters file if ``fit_gal_flag`` is ``True`` (and hence ``include_perturb_auf`` is ``True``):
 
@@ -199,7 +191,7 @@ and the inputs required if ``correct_astrometry`` is ``True``:
 ``best_mag_index``, ``nn_radius``, ``ref_csv_cat_file_string``, ``correct_mag_array``, ``correct_mag_slice``, ``correct_sig_slice``, ``chunk_overlap_col``, and ``best_mag_index_col``.
 
 .. note::
-    ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``, ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs`` are all currently required if ``correct_astrometry`` is ``True``, bypassing the nested flags above. For example, ``dens_dist`` is required as an input if ``compute_local_density`` and ``include_perturb_auf`` are both ``True``, or if ``correct_astrometry`` is set. This means that ``AstrometricCorrections`` implicitly always runs and fits for a full Astrometric Uncertainty Function.
+    ``run_fw_auf``, ``run_psf_auf``, ``psf_fwhms``, ``snr_mag_params_path``, ``download_tri``, ``tri_set_name``, ``tri_filt_names``, ``tri_filt_num``, ``tri_maglim_faint``, ``tri_num_faint``, ``dens_dist``, ``dd_params_path``, ``l_cut_path``, ``gal_wavs``, ``gal_zmax``, ``gal_nzs``, ``gal_aboffsets``, ``gal_filternames``, and ``gal_al_avs`` are all currently required if ``correct_astrometry`` is ``True``, bypassing the nested flags above. For example, ``dens_dist`` is required as an input if ``include_perturb_auf`` is ``True``, or if ``correct_astrometry`` is set. This means that ``AstrometricCorrections`` implicitly always runs and fits for a full Astrometric Uncertainty Function.
 
 .. note::
     ``snr_mag_params_path`` is currently also required if ``compute_snr_mag_relation`` is ``True``, bypassing the above flags. It is therefore currently a required input if any one of ``include_perturb_auf``, ``correct_astrometry``, or ``compute_snr_mag_relation`` are set to ``True``.
@@ -304,7 +296,7 @@ Alongside ``dd_params_path``, path to the ``.npy`` file containing the limiting 
 
 ``dens_dist``
 
-The radius, in arcseconds, within which to count internal catalogue sources for each object, to calculate the local source density. Used to scale TRILEGAL simulated source counts to match smaller scale density fluctuations. Only required if ``compute_local_density`` is ``True`` (and hence ``include_perturb_auf`` is also ``True``).
+The radius, in arcseconds, within which to count internal catalogue sources for each object, to calculate the local source density. Used to scale TRILEGAL simulated source counts to match smaller scale density fluctuations. Only required if ``include_perturb_auf`` is ``True``.
 
 ``gal_wavs``
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -81,9 +81,6 @@ crossmatch_params.txt::
     # Maximum extent of cross-match, used in non-all-sky cases to remove sources suffering potential edge effects -- min/max first axis coordinates (ra/l) then min/max second axis coordinates (dec/b)
     cross_match_extent = 0 0.25 50 50.3
 
-    # Number of chunks to break each catalogue into when splitting larger catalogues up for memory reasons
-    mem_chunk_num = 2
-
     # Integral fractions for various error circle cutouts used during the cross-match process. Should be space-separated floats, in the order of <bright error circle fraction>, <field error circle fraction>, <potential counterpart integral limit>
     int_fracs = 0.63 0.9 0.999
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -59,12 +59,6 @@ crossmatch_params.txt::
     # Check for whether we want to generate the csv file at the end of the run.
     make_output_csv = no
 
-    # Flags for each stage of the match process - must be "yes"/"no", "true"/"false", "t"/"f", or "1"/"0"
-    run_auf = yes
-    run_group = yes
-    run_cf = yes
-    run_source = yes
-
     # c/f region definition for photometric likelihood - either "rectangle" for NxM evenly spaced grid points, or "points" to define a list of two-point tuple coordinates, separated by a comma
     cf_region_type = rectangle
     # Frame of the coordinates must be specified -- either "equatorial" or "galactic"

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -8,7 +8,6 @@ import sys
 import numpy as np
 import warnings
 
-from .misc_functions import load_small_ref_auf_grid
 from .counterpart_pairing_fortran import counterpart_pairing_fortran as cpf
 
 __all__ = ['source_pairing']
@@ -16,7 +15,7 @@ __all__ = ['source_pairing']
 
 def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_filt_names,
                    b_filt_names, a_auf_pointings, b_auf_pointings, a_modelrefinds, b_modelrefinds,
-                   rho, drho, n_fracs, mem_chunk_num, group_sources_data, phot_like_data,
+                   rho, drho, n_fracs, group_sources_data, phot_like_data,
                    a_perturb_auf_outputs, b_perturb_auf_outputs):
     '''
     Function to iterate over all grouped islands of sources, calculating the
@@ -55,9 +54,6 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_fi
         The number of relative contamination fluxes previously considered
         when calculating the probability of a source being contaminated by
         a perturbing source brighter than a given flux.
-    mem_chunk_num : integer
-        Number of sub-arrays to break loading of main catalogue into, to
-        reduce the amount of memory used.
     group_sources_data : class.StageData
         Object containing all outputs from ``make_island_groupings``
         TODO Improve description
@@ -77,58 +73,10 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_fi
     print("Pairing sources...")
     sys.stdout.flush()
 
-    isle_len = group_sources_data.alist.shape[1]
+    agrplen = group_sources_data.agrplen
+    bgrplen = group_sources_data.bgrplen
 
-    match_chunk_lengths = np.empty(mem_chunk_num, int)
-    afield_chunk_lengths = np.empty(mem_chunk_num, int)
-    bfield_chunk_lengths = np.empty(mem_chunk_num, int)
-
-    match_chunk_lengths[0] = 0
-    afield_chunk_lengths[0] = 0
-    bfield_chunk_lengths[0] = 0
-    cprt_max_len, len_a, len_b = 0, 0, 0
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(isle_len*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(isle_len*(cnum+1)/mem_chunk_num).astype(int)
-
-        agrplen = group_sources_data.agrplen[lowind:highind]
-        bgrplen = group_sources_data.bgrplen[lowind:highind]
-
-        sum_agrp, sum_bgrp = np.sum(agrplen), np.sum(bgrplen)
-        match_lens = np.sum(np.minimum(agrplen, bgrplen))
-        if cnum < mem_chunk_num-1:
-            match_chunk_lengths[cnum+1] = match_chunk_lengths[cnum] + match_lens
-            afield_chunk_lengths[cnum+1] = afield_chunk_lengths[cnum] + sum_agrp
-            bfield_chunk_lengths[cnum+1] = bfield_chunk_lengths[cnum] + sum_bgrp
-
-        len_a += sum_agrp
-        len_b += sum_bgrp
-        cprt_max_len += match_lens
-
-    # Assume that the counterparts, at 100% match rate, can't be more than all
-    # of the items in the smaller of the two *list arrays.
-    acountinds = np.zeros(dtype=int, shape=(cprt_max_len,))
-    bcountinds = np.zeros(dtype=int, shape=(cprt_max_len,))
-    acontamprob = np.zeros(dtype=float, shape=(n_fracs, cprt_max_len), order='F')
-    bcontamprob = np.zeros(dtype=float, shape=(n_fracs, cprt_max_len), order='F')
-    acontamflux = np.zeros(dtype=float, shape=(cprt_max_len,))
-    bcontamflux = np.zeros(dtype=float, shape=(cprt_max_len,))
-    probcarray = np.zeros(dtype=float, shape=(cprt_max_len,))
-    etaarray = np.zeros(dtype=float, shape=(cprt_max_len,))
-    xiarray = np.zeros(dtype=float, shape=(cprt_max_len,))
-    crptseps = np.zeros(dtype=float, shape=(cprt_max_len,))
-    afieldinds = np.zeros(dtype=int, shape=(len_a,))
-    probfaarray = np.zeros(dtype=float, shape=(len_a,))
-    afieldflux = np.zeros(dtype=float, shape=(len_a,))
-    afieldseps = np.zeros(dtype=float, shape=(len_a,))
-    afieldeta = np.zeros(dtype=float, shape=(len_a,))
-    afieldxi = np.zeros(dtype=float, shape=(len_a,))
-    bfieldinds = np.zeros(dtype=int, shape=(len_b,))
-    probfbarray = np.zeros(dtype=float, shape=(len_b,))
-    bfieldflux = np.zeros(dtype=float, shape=(len_b,))
-    bfieldseps = np.zeros(dtype=float, shape=(len_b,))
-    bfieldeta = np.zeros(dtype=float, shape=(len_b,))
-    bfieldxi = np.zeros(dtype=float, shape=(len_b,))
+    len_a, len_b = np.sum(agrplen), np.sum(bgrplen)
 
     abinsarray = phot_like_data.abinsarray
     abinlengths = phot_like_data.abinlengths
@@ -142,128 +90,64 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_fi
     fb_priors = phot_like_data.fb_priors
     fb_array = phot_like_data.fb_array
 
-    big_len_a = len(np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path), mmap_mode='r'))
-    big_len_b = len(np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path), mmap_mode='r'))
+    alist = group_sources_data.alist
+    agrplen = group_sources_data.agrplen
+
+    a_astro = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path))
+    a_photo = np.load('{}/con_cat_photo.npy'.format(a_cat_folder_path))
+    amagref = np.load('{}/magref.npy'.format(a_cat_folder_path))
+
+    b_astro = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path))
+    b_photo = np.load('{}/con_cat_photo.npy'.format(b_cat_folder_path))
+    bmagref = np.load('{}/magref.npy'.format(b_cat_folder_path))
+
+    big_len_a = len(a_astro)
+    big_len_b = len(b_astro)
     # large_len is the "safe" initialisation value for arrays, such that no index
     # can ever reach this value.
     large_len = max(big_len_a, big_len_b)
 
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(isle_len*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(isle_len*(cnum+1)/mem_chunk_num).astype(int)
+    a_sky_inds = phot_like_data.a_sky_inds
 
-        alist_ = group_sources_data.alist[:, lowind:highind]
-        agrplen = group_sources_data.agrplen[lowind:highind]
+    blist = group_sources_data.blist
+    bgrplen = group_sources_data.bgrplen
 
-        alist_ = np.asfortranarray(alist_[:np.amax(agrplen), :])
-        alistunique_flat = np.unique(alist_[alist_ > -1])
-        a_astro = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path),
-                          mmap_mode='r')[alistunique_flat]
-        a_photo = np.load('{}/con_cat_photo.npy'.format(a_cat_folder_path),
-                          mmap_mode='r')[alistunique_flat]
-        amagref = np.load('{}/magref.npy'.format(a_cat_folder_path),
-                          mmap_mode='r')[alistunique_flat]
-        maparray = -1*np.ones(big_len_a+1).astype(int)
-        maparray[alistunique_flat] = np.arange(0, len(a_astro), dtype=int)
-        # *list maps the subarray indices, but *list_ keeps the full catalogue indices
-        alist = np.asfortranarray(maparray[alist_.flatten()].reshape(alist_.shape))
+    b_sky_inds = phot_like_data.b_sky_inds
 
-        a_sky_inds = phot_like_data.a_sky_inds[alistunique_flat]
+    afourier_grids = a_perturb_auf_outputs['fourier_grid']
+    afrac_grids = a_perturb_auf_outputs['frac_grid']
+    aflux_grids = a_perturb_auf_outputs['flux_grid']
+    bfourier_grids = b_perturb_auf_outputs['fourier_grid']
+    bfrac_grids = b_perturb_auf_outputs['frac_grid']
+    bflux_grids = b_perturb_auf_outputs['flux_grid']
 
-        blist_ = group_sources_data.blist[:, lowind:highind]
-        bgrplen = group_sources_data.bgrplen[lowind:highind]
+    # crpts_max_len is the maximum number of counterparts at 100% match rate.
+    cprt_max_len = np.sum(np.minimum(agrplen, bgrplen))
 
-        blist_ = np.asfortranarray(blist_[:np.amax(bgrplen), :])
-        blistunique_flat = np.unique(blist_[blist_ > -1])
-        b_astro = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path),
-                          mmap_mode='r')[blistunique_flat]
-        b_photo = np.load('{}/con_cat_photo.npy'.format(b_cat_folder_path),
-                          mmap_mode='r')[blistunique_flat]
-        bmagref = np.load('{}/magref.npy'.format(b_cat_folder_path),
-                          mmap_mode='r')[blistunique_flat]
-        maparray = -1*np.ones(big_len_b+1).astype(int)
-        maparray[blistunique_flat] = np.arange(0, len(b_astro), dtype=int)
-        blist = np.asfortranarray(maparray[blist_.flatten()].reshape(blist_.shape))
+    (acountinds, bcountinds, afieldinds, bfieldinds, acontamprob, bcontamprob, etaarray,
+     xiarray, acontamflux, bcontamflux, probcarray, crptseps, probfaarray, afieldfluxs,
+     afieldseps, afieldetas, afieldxis, probfbarray, bfieldfluxs, bfieldseps, bfieldetas,
+     bfieldxis) = cpf.find_island_probabilities(
+        a_astro, a_photo, b_astro, b_photo, alist, blist, agrplen, bgrplen,
+        c_array, fa_array, fb_array, c_priors, fa_priors, fb_priors, amagref, bmagref,
+        a_modelrefinds, b_modelrefinds, abinsarray, abinlengths, bbinsarray, bbinlengths,
+        afrac_grids, aflux_grids, bfrac_grids, bflux_grids, afourier_grids, bfourier_grids,
+        a_sky_inds, b_sky_inds, rho, drho, n_fracs, large_len, cprt_max_len)
 
-        b_sky_inds = phot_like_data.b_sky_inds[blistunique_flat]
-        amodrefind = a_modelrefinds[:, alistunique_flat]
-        bmodrefind = b_modelrefinds[:, blistunique_flat]
-
-        [afourier_grids, afrac_grids, aflux_grids], amodrefind = load_small_ref_auf_grid(
-            amodrefind, a_perturb_auf_outputs, ['fourier', 'frac', 'flux'])
-        [bfourier_grids, bfrac_grids, bflux_grids], bmodrefind = load_small_ref_auf_grid(
-            bmodrefind, b_perturb_auf_outputs, ['fourier', 'frac', 'flux'])
-
-
-        # Similar to crpts_max_len, mini_crpts_len is the maximum number of
-        # counterparts at 100% match rate for this cutout.
-        mini_crpts_len = np.sum(np.minimum(agrplen, bgrplen))
-
-        (_acountinds, _bcountinds, _afieldinds, _bfieldinds, _acontamprob, _bcontamprob, _etaarray,
-         _xiarray, _acontamflux, _bcontamflux, _probcarray, _crptseps, _probfaarray, _afieldfluxs,
-         _afieldseps, _afieldetas, _afieldxis, _probfbarray, _bfieldfluxs, _bfieldseps, _bfieldetas,
-         _bfieldxis) = cpf.find_island_probabilities(
-            a_astro, a_photo, b_astro, b_photo, alist, alist_, blist, blist_, agrplen, bgrplen,
-            c_array, fa_array, fb_array, c_priors, fa_priors, fb_priors, amagref, bmagref,
-            amodrefind, bmodrefind, abinsarray, abinlengths, bbinsarray, bbinlengths, afrac_grids,
-            aflux_grids, bfrac_grids, bflux_grids, afourier_grids, bfourier_grids, a_sky_inds,
-            b_sky_inds, rho, drho, n_fracs, large_len, mini_crpts_len)
-
-        ind_start, ind_end = match_chunk_lengths[cnum], match_chunk_lengths[cnum]+len(_acountinds)
-        acountinds[ind_start:ind_end] = _acountinds
-        bcountinds[ind_start:ind_end] = _bcountinds
-        acontamprob[:, ind_start:ind_end] = _acontamprob
-        bcontamprob[:, ind_start:ind_end] = _bcontamprob
-        etaarray[ind_start:ind_end] = _etaarray
-        xiarray[ind_start:ind_end] = _xiarray
-        acontamflux[ind_start:ind_end] = _acontamflux
-        bcontamflux[ind_start:ind_end] = _bcontamflux
-        probcarray[ind_start:ind_end] = _probcarray
-        crptseps[ind_start:ind_end] = _crptseps
-
-        ind_start, ind_end = afield_chunk_lengths[cnum], afield_chunk_lengths[cnum]+len(_afieldinds)
-        afieldinds[ind_start:ind_end] = _afieldinds
-        probfaarray[ind_start:ind_end] = _probfaarray
-        afieldflux[ind_start:ind_end] = _afieldfluxs
-        afieldseps[ind_start:ind_end] = _afieldseps
-        afieldeta[ind_start:ind_end] = _afieldetas
-        afieldxi[ind_start:ind_end] = _afieldxis
-
-        ind_start, ind_end = bfield_chunk_lengths[cnum], bfield_chunk_lengths[cnum]+len(_bfieldinds)
-        bfieldinds[ind_start:ind_end] = _bfieldinds
-        probfbarray[ind_start:ind_end] = _probfbarray
-        bfieldflux[ind_start:ind_end] = _bfieldfluxs
-        bfieldseps[ind_start:ind_end] = _bfieldseps
-        bfieldeta[ind_start:ind_end] = _bfieldetas
-        bfieldxi[ind_start:ind_end] = _bfieldxis
-
-    countfilter = np.zeros(dtype=bool, shape=(cprt_max_len,))
     afieldfilter = np.zeros(dtype=bool, shape=(len_a,))
     bfieldfilter = np.zeros(dtype=bool, shape=(len_b,))
 
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(cprt_max_len*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(cprt_max_len*(cnum+1)/mem_chunk_num).astype(int)
-        # *contamprob is (smalllen, nfracs) in shape and our check for correctness needs to check
-        # all nfrac values, requiring an all check.
-        countfilter[lowind:highind] = (
-            (acountinds[lowind:highind] < large_len+1) &
-            (bcountinds[lowind:highind] < large_len+1) &
-            np.all(acontamprob[:, lowind:highind] >= 0, axis=0) &
-            np.all(bcontamprob[:, lowind:highind] >= 0, axis=0) &
-            (acontamflux[lowind:highind] >= 0) & (bcontamflux[lowind:highind] >= 0) &
-            (probcarray[lowind:highind] >= 0) & (etaarray[lowind:highind] >= -30) &
-            (xiarray[lowind:highind] >= -30))
+    # *contamprob is (smalllen, nfracs) in shape and our check for correctness needs to check
+    # all nfrac values, requiring an all check.
+    countfilter = (
+        (acountinds < large_len+1) & (bcountinds < large_len+1) &
+        np.all(acontamprob >= 0, axis=0) & np.all(bcontamprob >= 0, axis=0) &
+        (acontamflux >= 0) & (bcontamflux >= 0) & (probcarray >= 0) & (etaarray >= -30) &
+        (xiarray >= -30))
 
-        lowind = np.floor(len_a*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(len_a*(cnum+1)/mem_chunk_num).astype(int)
-        afieldfilter[lowind:highind] = ((afieldinds[lowind:highind] < large_len+1) &
-                                        (probfaarray[lowind:highind] >= 0))
+    afieldfilter = ((afieldinds < large_len+1) & (probfaarray >= 0))
 
-        lowind = np.floor(len_b*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(len_b*(cnum+1)/mem_chunk_num).astype(int)
-        bfieldfilter[lowind:highind] = ((bfieldinds[lowind:highind] < large_len+1) &
-                                        (probfbarray[lowind:highind] >= 0))
+    bfieldfilter = ((bfieldinds < large_len+1) & (probfbarray >= 0))
 
     lenrejecta = group_sources_data.lenrejecta
     lenrejectb = group_sources_data.lenrejectb
@@ -274,47 +158,25 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_fi
 
     # Reduce size of output files, removing anything that doesn't meet the
     # criteria above from all saved numpy arrays.
-    for file_name, variable, small_shape, typing, filter_variable in zip(
+    for file_name, variable, filter_variable in zip(
         ['ac', 'bc', 'pacontam', 'pbcontam', 'acontamflux', 'bcontamflux', 'af', 'bf', 'pc', 'eta',
          'xi', 'pfa', 'pfb', 'afieldflux', 'bfieldflux', 'crptseps', 'afieldseps', 'afieldeta',
          'afieldxi', 'bfieldseps', 'bfieldeta', 'bfieldxi'],
         [acountinds, bcountinds, acontamprob, bcontamprob, acontamflux, bcontamflux, afieldinds,
-         bfieldinds, probcarray, etaarray, xiarray, probfaarray, probfbarray, afieldflux,
-         bfieldflux, crptseps, afieldseps, afieldeta, afieldxi, bfieldseps, bfieldeta, bfieldxi],
-        [(countsum,), (countsum,), (n_fracs, countsum), (n_fracs, countsum), (countsum,),
-         (countsum,), (afieldsum,), (bfieldsum,), (countsum,), (countsum,), (countsum,),
-         (afieldsum,), (bfieldsum,), (afieldsum,), (bfieldsum,), (countsum,), (afieldsum,),
-         (afieldsum,), (afieldsum,), (bfieldsum,), (bfieldsum,), (bfieldsum,)],
-        [int, int, float, float, float, float, int, int, float, float, float, float, float,
-         float, float, float, float, float, float, float, float, float],
+         bfieldinds, probcarray, etaarray, xiarray, probfaarray, probfbarray, afieldfluxs,
+         bfieldfluxs, crptseps, afieldseps, afieldetas, afieldxis, bfieldseps, bfieldetas,
+         bfieldxis],
         [countfilter, countfilter, countfilter, countfilter, countfilter, countfilter,
          afieldfilter, bfieldfilter, countfilter, countfilter, countfilter, afieldfilter,
          bfieldfilter, afieldfilter, bfieldfilter, countfilter, afieldfilter, afieldfilter,
          afieldfilter, bfieldfilter, bfieldfilter, bfieldfilter]):
 
-        temp_variable = np.zeros(dtype=typing, shape=small_shape)
         if file_name == 'pacontam' or file_name == 'pbcontam':
-            large_shape = variable.shape[1]
+            temp_variable = variable[:, filter_variable]
         else:
-            large_shape = variable.shape[0]
-        di = max(1, large_shape // 20)
-        temp_c = 0
-        if file_name == 'pacontam' or file_name == 'pbcontam':
-            for i in range(0, large_shape, di):
-                n_extra = int(np.sum(filter_variable[i:i+di]))
-                temp_variable[:, temp_c:temp_c+n_extra] = variable[:, i:i+di][:, filter_variable[i:i+di]]
-                temp_c += n_extra
-        else:
-            for i in range(0, large_shape, di):
-                n_extra = int(np.sum(filter_variable[i:i+di]))
-                temp_variable[temp_c:temp_c+n_extra] = variable[i:i+di][filter_variable[i:i+di]]
-                temp_c += n_extra
+            temp_variable = variable[filter_variable]
         np.save('{}/pairing/{}.npy'.format(joint_folder_path, file_name), temp_variable)
 
-    del acountinds, bcountinds, acontamprob, bcontamprob, acontamflux, bcontamflux, afieldinds
-    del bfieldinds, probcarray, etaarray, xiarray, probfaarray, probfbarray
-    del afieldflux, bfieldflux
-    del crptseps, afieldseps, afieldeta, afieldxi, bfieldseps, bfieldeta, bfieldxi
     tot = countsum + afieldsum + lenrejecta
     if tot < big_len_a:
         warnings.warn("{} catalogue a source{} not in either counterpart, field, or rejected "
@@ -332,7 +194,5 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_fi
                       "carefully".format(tot - big_len_b, 'indices' if tot - big_len_b > 1 else
                                          'index'))
     sys.stdout.flush()
-
-    del countfilter, afieldfilter, bfieldfilter
 
     return

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -14,10 +14,10 @@ from .counterpart_pairing_fortran import counterpart_pairing_fortran as cpf
 __all__ = ['source_pairing']
 
 
-def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_auf_folder_path,
-                   b_auf_folder_path, a_filt_names, b_filt_names, a_auf_pointings, b_auf_pointings,
-                   a_modelrefinds, b_modelrefinds, rho, drho, n_fracs, mem_chunk_num,
-                   group_sources_data, phot_like_data):
+def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_filt_names,
+                   b_filt_names, a_auf_pointings, b_auf_pointings, a_modelrefinds, b_modelrefinds,
+                   rho, drho, n_fracs, mem_chunk_num, group_sources_data, phot_like_data,
+                   a_perturb_auf_outputs, b_perturb_auf_outputs):
     '''
     Function to iterate over all grouped islands of sources, calculating the
     probabilities of all permutations of matches and deriving the most likely
@@ -31,11 +31,6 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         Folder in which the "a" catalogue input catalogues are stored.
     b_cat_folder_path : string
         Folder where catalogue "b" files are located.
-    a_auf_folder_path : string
-        Folder where catalogue "a" perturbation AUF component files were saved
-        previously.
-    b_auf_folder_path : string
-        Folder containing catalogue "b" perturbation AUF component files.
     a_filt_names : numpy.ndarray or list of strings
         Array or list containing names of the filters used in catalogue "a".
     b_filt_names : numpy.ndarray or list of strings
@@ -69,6 +64,12 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
     phot_like_data : class.StageData
         Object containing all outputs from ``compute_photometric_likelihoods``
         TODO Improve description
+    a_perturb_auf_outputs : dictionary
+        Dict containing the results from the previous step of the cross-match,
+        the simulations of the perturbation component of catalogue a's AUF.
+    b_perturb_auf_outputs : dictionary
+        Dict containing the results from the previous step of the cross-match,
+        the simulations of the perturbation component of catalogue b's AUF.
     '''
     print("Creating catalogue matches...")
     sys.stdout.flush()
@@ -189,9 +190,9 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         bmodrefind = b_modelrefinds[:, blistunique_flat]
 
         [afourier_grids, afrac_grids, aflux_grids], amodrefind = load_small_ref_auf_grid(
-            amodrefind, a_auf_folder_path, ['fourier', 'frac', 'flux'])
+            amodrefind, a_perturb_auf_outputs, ['fourier', 'frac', 'flux'])
         [bfourier_grids, bfrac_grids, bflux_grids], bmodrefind = load_small_ref_auf_grid(
-            bmodrefind, b_auf_folder_path, ['fourier', 'frac', 'flux'])
+            bmodrefind, b_perturb_auf_outputs, ['fourier', 'frac', 'flux'])
 
 
         # Similar to crpts_max_len, mini_crpts_len is the maximum number of

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -4,7 +4,6 @@ This module provides the functionality for the final cross-match process, the
 act of actually pairing sources across the two catalogues as counterparts.
 '''
 
-import os
 import sys
 import numpy as np
 import warnings

--- a/macauff/counterpart_pairing.py
+++ b/macauff/counterpart_pairing.py
@@ -18,7 +18,7 @@ __all__ = ['source_pairing']
 def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_auf_folder_path,
                    b_auf_folder_path, a_filt_names, b_filt_names, a_auf_pointings, b_auf_pointings,
                    a_modelrefinds, b_modelrefinds, rho, drho, n_fracs, mem_chunk_num,
-                   group_sources_data, phot_like_data, use_memmap_files):
+                   group_sources_data, phot_like_data):
     '''
     Function to iterate over all grouped islands of sources, calculating the
     probabilities of all permutations of matches and deriving the most likely
@@ -48,12 +48,10 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         Sky coordinates of locations of catalogue "b" perturbation AUF
         component simulations.
     a_modelrefinds : numpy.ndarray
-        Catalogue "a" modelrefinds array output from ``create_perturb_auf``. Used
-        only when use_memmap_files is False.
+        Catalogue "a" modelrefinds array output from ``create_perturb_auf``.
         TODO Improve description
     b_modelrefinds : numpy.ndarray
-        Catalogue "b" modelrefinds array output from ``create_perturb_auf``. Used
-        only when use_memmap_files is False.
+        Catalogue "b" modelrefinds array output from ``create_perturb_auf``.
         TODO Improve description
     rho : numpy.ndarray
         Array of fourier-space values, used in the convolution of PDFs.
@@ -68,16 +66,10 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         reduce the amount of memory used.
     group_sources_data : class.StageData
         Object containing all outputs from ``make_island_groupings``
-        Used only when use_memmap_files is False.
         TODO Improve description
     phot_like_data : class.StageData
         Object containing all outputs from ``compute_photometric_likelihoods``
-        Used only when use_memmap_files is False.
         TODO Improve description
-    use_memmap_files : boolean
-        When set to True, memory mapped files are used for several internal
-        arrays. Reduces memory consumption at the cost of increased I/O
-        contention.
     '''
     print("Creating catalogue matches...")
     sys.stdout.flush()
@@ -85,10 +77,7 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
     print("Pairing sources...")
     sys.stdout.flush()
 
-    if use_memmap_files:
-        isle_len = np.load('{}/group/alist.npy'.format(joint_folder_path), mmap_mode='r').shape[1]
-    else:
-        isle_len = group_sources_data.alist.shape[1]
+    isle_len = group_sources_data.alist.shape[1]
 
     match_chunk_lengths = np.empty(mem_chunk_num, int)
     afield_chunk_lengths = np.empty(mem_chunk_num, int)
@@ -102,14 +91,8 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         lowind = np.floor(isle_len*cnum/mem_chunk_num).astype(int)
         highind = np.floor(isle_len*(cnum+1)/mem_chunk_num).astype(int)
 
-        if use_memmap_files:
-            agrplen = np.load('{}/group/agrplen.npy'.format(joint_folder_path),
-                            mmap_mode='r')[lowind:highind]
-            bgrplen = np.load('{}/group/bgrplen.npy'.format(joint_folder_path),
-                            mmap_mode='r')[lowind:highind]
-        else:
-            agrplen = group_sources_data.agrplen[lowind:highind]
-            bgrplen = group_sources_data.bgrplen[lowind:highind]
+        agrplen = group_sources_data.agrplen[lowind:highind]
+        bgrplen = group_sources_data.bgrplen[lowind:highind]
 
         sum_agrp, sum_bgrp = np.sum(agrplen), np.sum(bgrplen)
         match_lens = np.sum(np.minimum(agrplen, bgrplen))
@@ -124,100 +107,40 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
 
     # Assume that the counterparts, at 100% match rate, can't be more than all
     # of the items in the smaller of the two *list arrays.
-    if use_memmap_files:
-        acountinds = np.lib.format.open_memmap('{}/pairing/ac.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=int, shape=(cprt_max_len,))
-        bcountinds = np.lib.format.open_memmap('{}/pairing/bc.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=int, shape=(cprt_max_len,))
-        acontamprob = np.lib.format.open_memmap('{}/pairing/pacontam.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=float, shape=(n_fracs, cprt_max_len),
-                                                fortran_order=True)
-        bcontamprob = np.lib.format.open_memmap('{}/pairing/pbcontam.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=float, shape=(n_fracs, cprt_max_len),
-                                                fortran_order=True)
-        acontamflux = np.lib.format.open_memmap('{}/pairing/acontamflux.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=float, shape=(cprt_max_len,))
-        bcontamflux = np.lib.format.open_memmap('{}/pairing/bcontamflux.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=float, shape=(cprt_max_len,))
-        probcarray = np.lib.format.open_memmap('{}/pairing/pc.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(cprt_max_len,))
-        etaarray = np.lib.format.open_memmap('{}/pairing/eta.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(cprt_max_len,))
-        xiarray = np.lib.format.open_memmap('{}/pairing/xi.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(cprt_max_len,))
-        crptseps = np.lib.format.open_memmap('{}/pairing/crptseps.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(cprt_max_len,))
-        afieldinds = np.lib.format.open_memmap('{}/pairing/af.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=int, shape=(len_a,))
-        probfaarray = np.lib.format.open_memmap('{}/pairing/pfa.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=float, shape=(len_a,))
-        afieldflux = np.lib.format.open_memmap('{}/pairing/afieldflux.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_a,))
-        afieldseps = np.lib.format.open_memmap('{}/pairing/afieldseps.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_a,))
-        afieldeta = np.lib.format.open_memmap('{}/pairing/afieldeta.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_a,))
-        afieldxi = np.lib.format.open_memmap('{}/pairing/afieldxi.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_a,))
-        bfieldinds = np.lib.format.open_memmap('{}/pairing/bf.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=int, shape=(len_b,))
-        probfbarray = np.lib.format.open_memmap('{}/pairing/pfb.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=float, shape=(len_b,))
-        bfieldflux = np.lib.format.open_memmap('{}/pairing/bfieldflux.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_b,))
-        bfieldseps = np.lib.format.open_memmap('{}/pairing/bfieldseps.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_b,))
-        bfieldeta = np.lib.format.open_memmap('{}/pairing/bfieldeta.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_b,))
-        bfieldxi = np.lib.format.open_memmap('{}/pairing/bfieldxi.npy'.format(joint_folder_path),
-                                            mode='w+', dtype=float, shape=(len_b,))
+    acountinds = np.zeros(dtype=int, shape=(cprt_max_len,))
+    bcountinds = np.zeros(dtype=int, shape=(cprt_max_len,))
+    acontamprob = np.zeros(dtype=float, shape=(n_fracs, cprt_max_len), order='F')
+    bcontamprob = np.zeros(dtype=float, shape=(n_fracs, cprt_max_len), order='F')
+    acontamflux = np.zeros(dtype=float, shape=(cprt_max_len,))
+    bcontamflux = np.zeros(dtype=float, shape=(cprt_max_len,))
+    probcarray = np.zeros(dtype=float, shape=(cprt_max_len,))
+    etaarray = np.zeros(dtype=float, shape=(cprt_max_len,))
+    xiarray = np.zeros(dtype=float, shape=(cprt_max_len,))
+    crptseps = np.zeros(dtype=float, shape=(cprt_max_len,))
+    afieldinds = np.zeros(dtype=int, shape=(len_a,))
+    probfaarray = np.zeros(dtype=float, shape=(len_a,))
+    afieldflux = np.zeros(dtype=float, shape=(len_a,))
+    afieldseps = np.zeros(dtype=float, shape=(len_a,))
+    afieldeta = np.zeros(dtype=float, shape=(len_a,))
+    afieldxi = np.zeros(dtype=float, shape=(len_a,))
+    bfieldinds = np.zeros(dtype=int, shape=(len_b,))
+    probfbarray = np.zeros(dtype=float, shape=(len_b,))
+    bfieldflux = np.zeros(dtype=float, shape=(len_b,))
+    bfieldseps = np.zeros(dtype=float, shape=(len_b,))
+    bfieldeta = np.zeros(dtype=float, shape=(len_b,))
+    bfieldxi = np.zeros(dtype=float, shape=(len_b,))
 
-        abinsarray = np.load('{}/phot_like/abinsarray.npy'.format(joint_folder_path), mmap_mode='r')
-        abinlengths = np.load('{}/phot_like/abinlengths.npy'.format(joint_folder_path), mmap_mode='r')
-        bbinsarray = np.load('{}/phot_like/bbinsarray.npy'.format(joint_folder_path), mmap_mode='r')
-        bbinlengths = np.load('{}/phot_like/bbinlengths.npy'.format(joint_folder_path), mmap_mode='r')
+    abinsarray = phot_like_data.abinsarray
+    abinlengths = phot_like_data.abinlengths
+    bbinsarray = phot_like_data.bbinsarray
+    bbinlengths = phot_like_data.bbinlengths
 
-        c_priors = np.load('{}/phot_like/c_priors.npy'.format(joint_folder_path), mmap_mode='r')
-        c_array = np.load('{}/phot_like/c_array.npy'.format(joint_folder_path), mmap_mode='r')
-        fa_priors = np.load('{}/phot_like/fa_priors.npy'.format(joint_folder_path), mmap_mode='r')
-        fa_array = np.load('{}/phot_like/fa_array.npy'.format(joint_folder_path), mmap_mode='r')
-        fb_priors = np.load('{}/phot_like/fb_priors.npy'.format(joint_folder_path), mmap_mode='r')
-        fb_array = np.load('{}/phot_like/fb_array.npy'.format(joint_folder_path), mmap_mode='r')
-    else:
-        acountinds = np.zeros(dtype=int, shape=(cprt_max_len,))
-        bcountinds = np.zeros(dtype=int, shape=(cprt_max_len,))
-        acontamprob = np.zeros(dtype=float, shape=(n_fracs, cprt_max_len), order='F')
-        bcontamprob = np.zeros(dtype=float, shape=(n_fracs, cprt_max_len), order='F')
-        acontamflux = np.zeros(dtype=float, shape=(cprt_max_len,))
-        bcontamflux = np.zeros(dtype=float, shape=(cprt_max_len,))
-        probcarray = np.zeros(dtype=float, shape=(cprt_max_len,))
-        etaarray = np.zeros(dtype=float, shape=(cprt_max_len,))
-        xiarray = np.zeros(dtype=float, shape=(cprt_max_len,))
-        crptseps = np.zeros(dtype=float, shape=(cprt_max_len,))
-        afieldinds = np.zeros(dtype=int, shape=(len_a,))
-        probfaarray = np.zeros(dtype=float, shape=(len_a,))
-        afieldflux = np.zeros(dtype=float, shape=(len_a,))
-        afieldseps = np.zeros(dtype=float, shape=(len_a,))
-        afieldeta = np.zeros(dtype=float, shape=(len_a,))
-        afieldxi = np.zeros(dtype=float, shape=(len_a,))
-        bfieldinds = np.zeros(dtype=int, shape=(len_b,))
-        probfbarray = np.zeros(dtype=float, shape=(len_b,))
-        bfieldflux = np.zeros(dtype=float, shape=(len_b,))
-        bfieldseps = np.zeros(dtype=float, shape=(len_b,))
-        bfieldeta = np.zeros(dtype=float, shape=(len_b,))
-        bfieldxi = np.zeros(dtype=float, shape=(len_b,))
-
-        abinsarray = phot_like_data.abinsarray
-        abinlengths = phot_like_data.abinlengths
-        bbinsarray = phot_like_data.bbinsarray
-        bbinlengths = phot_like_data.bbinlengths
-
-        c_priors = phot_like_data.c_priors
-        c_array = phot_like_data.c_array
-        fa_priors = phot_like_data.fa_priors
-        fa_array = phot_like_data.fa_array
-        fb_priors = phot_like_data.fb_priors
-        fb_array = phot_like_data.fb_array
+    c_priors = phot_like_data.c_priors
+    c_array = phot_like_data.c_array
+    fa_priors = phot_like_data.fa_priors
+    fa_array = phot_like_data.fa_array
+    fb_priors = phot_like_data.fb_priors
+    fb_array = phot_like_data.fb_array
 
     big_len_a = len(np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path), mmap_mode='r'))
     big_len_b = len(np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path), mmap_mode='r'))
@@ -229,14 +152,8 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         lowind = np.floor(isle_len*cnum/mem_chunk_num).astype(int)
         highind = np.floor(isle_len*(cnum+1)/mem_chunk_num).astype(int)
 
-        if use_memmap_files:
-            alist_ = np.load('{}/group/alist.npy'.format(joint_folder_path),
-                            mmap_mode='r')[:, lowind:highind]
-            agrplen = np.load('{}/group/agrplen.npy'.format(joint_folder_path),
-                            mmap_mode='r')[lowind:highind]
-        else:
-            alist_ = group_sources_data.alist[:, lowind:highind]
-            agrplen = group_sources_data.agrplen[lowind:highind]
+        alist_ = group_sources_data.alist[:, lowind:highind]
+        agrplen = group_sources_data.agrplen[lowind:highind]
 
         alist_ = np.asfortranarray(alist_[:np.amax(agrplen), :])
         alistunique_flat = np.unique(alist_[alist_ > -1])
@@ -251,19 +168,10 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         # *list maps the subarray indices, but *list_ keeps the full catalogue indices
         alist = np.asfortranarray(maparray[alist_.flatten()].reshape(alist_.shape))
 
-        if use_memmap_files:
-            a_sky_inds = np.load('{}/phot_like/a_sky_inds.npy'.format(joint_folder_path),
-                                mmap_mode='r')[alistunique_flat]
+        a_sky_inds = phot_like_data.a_sky_inds[alistunique_flat]
 
-            blist_ = np.load('{}/group/blist.npy'.format(joint_folder_path),
-                            mmap_mode='r')[:, lowind:highind]
-            bgrplen = np.load('{}/group/bgrplen.npy'.format(joint_folder_path),
-                            mmap_mode='r')[lowind:highind]
-        else:
-            a_sky_inds = phot_like_data.a_sky_inds[alistunique_flat]
-
-            blist_ = group_sources_data.blist[:, lowind:highind]
-            bgrplen = group_sources_data.bgrplen[lowind:highind]
+        blist_ = group_sources_data.blist[:, lowind:highind]
+        bgrplen = group_sources_data.bgrplen[lowind:highind]
 
         blist_ = np.asfortranarray(blist_[:np.amax(bgrplen), :])
         blistunique_flat = np.unique(blist_[blist_ > -1])
@@ -277,18 +185,9 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         maparray[blistunique_flat] = np.arange(0, len(b_astro), dtype=int)
         blist = np.asfortranarray(maparray[blist_.flatten()].reshape(blist_.shape))
 
-        if use_memmap_files:
-            b_sky_inds = np.load('{}/phot_like/b_sky_inds.npy'.format(joint_folder_path),
-                        mmap_mode='r')[blistunique_flat]
-
-            amodrefind = np.load('{}/modelrefinds.npy'.format(a_auf_folder_path),
-                                mmap_mode='r')[:, alistunique_flat]
-            bmodrefind = np.load('{}/modelrefinds.npy'.format(b_auf_folder_path),
-                                mmap_mode='r')[:, blistunique_flat]
-        else:
-            b_sky_inds = phot_like_data.b_sky_inds[blistunique_flat]
-            amodrefind = a_modelrefinds[:, alistunique_flat]
-            bmodrefind = b_modelrefinds[:, blistunique_flat]
+        b_sky_inds = phot_like_data.b_sky_inds[blistunique_flat]
+        amodrefind = a_modelrefinds[:, alistunique_flat]
+        bmodrefind = b_modelrefinds[:, blistunique_flat]
 
         [afourier_grids, afrac_grids, aflux_grids], amodrefind = load_small_ref_auf_grid(
             amodrefind, a_auf_folder_path, ['fourier', 'frac', 'flux'])
@@ -338,17 +237,9 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         bfieldeta[ind_start:ind_end] = _bfieldetas
         bfieldxi[ind_start:ind_end] = _bfieldxis
 
-    if use_memmap_files:
-        countfilter = np.lib.format.open_memmap('{}/pairing/countfilt.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=bool, shape=(cprt_max_len,))
-        afieldfilter = np.lib.format.open_memmap('{}/pairing/afieldfilt.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=bool, shape=(len_a,))
-        bfieldfilter = np.lib.format.open_memmap('{}/pairing/bfieldfilt.npy'.format(joint_folder_path),
-                                                mode='w+', dtype=bool, shape=(len_b,))
-    else:
-        countfilter = np.zeros(dtype=bool, shape=(cprt_max_len,))
-        afieldfilter = np.zeros(dtype=bool, shape=(len_a,))
-        bfieldfilter = np.zeros(dtype=bool, shape=(len_b,))
+    countfilter = np.zeros(dtype=bool, shape=(cprt_max_len,))
+    afieldfilter = np.zeros(dtype=bool, shape=(len_a,))
+    bfieldfilter = np.zeros(dtype=bool, shape=(len_b,))
 
     for cnum in range(0, mem_chunk_num):
         lowind = np.floor(cprt_max_len*cnum/mem_chunk_num).astype(int)
@@ -374,20 +265,8 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
         bfieldfilter[lowind:highind] = ((bfieldinds[lowind:highind] < large_len+1) &
                                         (probfbarray[lowind:highind] >= 0))
 
-    if use_memmap_files:
-        if os.path.isfile('{}/reject/reject_a.npy'.format(joint_folder_path)):
-            lenrejecta = len(np.load('{}/reject/reject_a.npy'.format(joint_folder_path),
-                                    mmap_mode='r'))
-        else:
-            lenrejecta = 0
-        if os.path.isfile('{}/reject/reject_b.npy'.format(joint_folder_path)):
-            lenrejectb = len(np.load('{}/reject/reject_b.npy'.format(joint_folder_path),
-                                    mmap_mode='r'))
-        else:
-            lenrejectb = 0
-    else:
-        lenrejecta = group_sources_data.lenrejecta
-        lenrejectb = group_sources_data.lenrejectb
+    lenrejecta = group_sources_data.lenrejecta
+    lenrejectb = group_sources_data.lenrejectb
 
     countsum = int(np.sum(countfilter))
     afieldsum = int(np.sum(afieldfilter))
@@ -413,11 +292,7 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
          bfieldfilter, afieldfilter, bfieldfilter, countfilter, afieldfilter, afieldfilter,
          afieldfilter, bfieldfilter, bfieldfilter, bfieldfilter]):
 
-        if use_memmap_files:
-            temp_variable = np.lib.format.open_memmap('{}/pairing/{}2.npy'.format(
-                joint_folder_path, file_name), mode='w+', dtype=typing, shape=small_shape)
-        else:
-            temp_variable = np.zeros(dtype=typing, shape=small_shape)
+        temp_variable = np.zeros(dtype=typing, shape=small_shape)
         if file_name == 'pacontam' or file_name == 'pbcontam':
             large_shape = variable.shape[1]
         else:
@@ -434,11 +309,7 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
                 n_extra = int(np.sum(filter_variable[i:i+di]))
                 temp_variable[temp_c:temp_c+n_extra] = variable[i:i+di][filter_variable[i:i+di]]
                 temp_c += n_extra
-        if use_memmap_files:
-            os.system('mv {}/pairing/{}2.npy {}/pairing/{}.npy'.format(joint_folder_path, file_name,
-                    joint_folder_path, file_name))
-        else:
-            np.save('{}/pairing/{}.npy'.format(joint_folder_path, file_name), temp_variable)
+        np.save('{}/pairing/{}.npy'.format(joint_folder_path, file_name), temp_variable)
 
     del acountinds, bcountinds, acontamprob, bcontamprob, acontamflux, bcontamflux, afieldinds
     del bfieldinds, probcarray, etaarray, xiarray, probfaarray, probfbarray
@@ -463,9 +334,5 @@ def source_pairing(joint_folder_path, a_cat_folder_path, b_cat_folder_path, a_au
     sys.stdout.flush()
 
     del countfilter, afieldfilter, bfieldfilter
-    if use_memmap_files:
-        os.remove('{}/pairing/countfilt.npy'.format(joint_folder_path))
-        os.remove('{}/pairing/afieldfilt.npy'.format(joint_folder_path))
-        os.remove('{}/pairing/bfieldfilt.npy'.format(joint_folder_path))
 
     return

--- a/macauff/counterpart_pairing_fortran.f90
+++ b/macauff/counterpart_pairing_fortran.f90
@@ -33,8 +33,6 @@ subroutine find_island_probabilities(a_astro, a_photo, b_astro, b_photo, alist, 
     ! Number of contaminant fractions simulated in the perturbation AUF, and total lengths of small and
     ! large catalogues.
     integer, intent(in) :: n_fracs, large_len, mini_crpts_len
-    ! TODO: *binsarray, *binslength, *_priors and *_array are all memmapped. Does this matter in practice?
-    ! Should be able to take unique-sky-slice cutouts, but this'll need convenience functions for the slicing.
     ! Astrometry and photometry for the two respective catalogues.
     real(dp), intent(in) :: a_astro(:, :), a_photo(:, :), b_astro(:, :), b_photo(:, :)
     ! Photometric "counterpart" and "field" likelihood and prior arrays.

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -139,12 +139,6 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     a_full = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path), mmap_mode='r')
     b_full = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path), mmap_mode='r')
 
-    # Generate the necessary memmap sky slice arrays now.
-    memmap_slice_arrays_a = []
-    memmap_slice_arrays_b = []
-    for _ in range(5):
-        memmap_slice_arrays_a.append(np.zeros(dtype=bool, shape=(len(a_full),)))
-        memmap_slice_arrays_b.append(np.zeros(dtype=bool, shape=(len(b_full),)))
     asize = np.zeros(dtype=int, shape=(len(a_full),))
     bsize = np.zeros(dtype=int, shape=(len(b_full),))
 
@@ -154,10 +148,10 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                                                                    ax2_sparse_loops[1:])):
             a_big_sky_cut = _load_rectangular_slice(
                 joint_folder_path, '', a_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, 0, memmap_slice_arrays_a)
+                ax2_sparse_end, 0)
             b_big_sky_cut = _load_rectangular_slice(
                 joint_folder_path, '', b_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, max_sep, memmap_slice_arrays_b)
+                ax2_sparse_end, max_sep)
             a_cutout = a_full[a_big_sky_cut]
             b_cutout = b_full[b_big_sky_cut]
 
@@ -179,12 +173,10 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                     ax_cutout = [ax1_start, ax1_end, ax2_start, ax2_end]
                     a, afouriergrid, amodrefindsmall, a_cut = _load_fourier_grid_cutouts(
                         a_cutout, ax_cutout, joint_folder_path, a_cat_folder_path,
-                        a_perturb_auf_outputs, 0, 'a', small_memmap_slice_arrays_a, a_big_sky_cut,
-                        a_modelrefinds)
+                        a_perturb_auf_outputs, 0, 'a', a_big_sky_cut, a_modelrefinds)
                     b, bfouriergrid, bmodrefindsmall, b_cut = _load_fourier_grid_cutouts(
                         b_cutout, ax_cutout, joint_folder_path, b_cat_folder_path,
-                        b_perturb_auf_outputs, max_sep, 'b', small_memmap_slice_arrays_b,
-                        b_big_sky_cut, b_modelrefinds)
+                        b_perturb_auf_outputs, max_sep, 'b', b_big_sky_cut, b_modelrefinds)
 
                     if len(a) > 0 and len(b) > 0:
                         overlapa, overlapb = gsf.get_max_overlap(
@@ -219,10 +211,10 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                                                                    ax2_sparse_loops[1:])):
             a_big_sky_cut = _load_rectangular_slice(
                 joint_folder_path, '', a_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, 0, memmap_slice_arrays_a)
+                ax2_sparse_end, 0)
             b_big_sky_cut = _load_rectangular_slice(
                 joint_folder_path, '', b_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, max_sep, memmap_slice_arrays_b)
+                ax2_sparse_end, max_sep)
             a_cutout = a_full[a_big_sky_cut]
             b_cutout = b_full[b_big_sky_cut]
 
@@ -241,12 +233,10 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                     ax_cutout = [ax1_start, ax1_end, ax2_start, ax2_end]
                     a, afouriergrid, amodrefindsmall, a_cut = _load_fourier_grid_cutouts(
                         a_cutout, ax_cutout, joint_folder_path, a_cat_folder_path,
-                        a_perturb_auf_outputs, 0, 'a', small_memmap_slice_arrays_a, a_big_sky_cut,
-                        a_modelrefinds)
+                        a_perturb_auf_outputs, 0, 'a', a_big_sky_cut, a_modelrefinds)
                     b, bfouriergrid, bmodrefindsmall, b_cut = _load_fourier_grid_cutouts(
                         b_cutout, ax_cutout, joint_folder_path, b_cat_folder_path,
-                        b_perturb_auf_outputs, max_sep, 'b', small_memmap_slice_arrays_b,
-                        b_big_sky_cut, b_modelrefinds)
+                        b_perturb_auf_outputs, max_sep, 'b', b_big_sky_cut, b_modelrefinds)
 
                     if len(a) > 0 and len(b) > 0:
                         indicesa, indicesb, overlapa, overlapb = gsf.get_overlap_indices(
@@ -504,8 +494,8 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
 
 
 def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder_path,
-                               perturb_auf_outputs, padding, cat_name, memmap_slice_arrays,
-                               large_sky_slice, modelrefinds):
+                               perturb_auf_outputs, padding, cat_name, large_sky_slice,
+                               modelrefinds):
     '''
     Function to load a sub-set of a given catalogue's astrometry, slicing it
     in a given sky coordinate rectangle, and load the appropriate sub-array
@@ -534,9 +524,6 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     cat_name : string
         String indicating whether we are loading cutouts from catalogue "a" or
         "b".
-    memmap_slice_arrays : list of numpy.ndarray
-        List of the memmap sky slice arrays, to be used in the loading of the
-        rectangular sky patch.
     large_sky_slice : boolean
         Slice array containing the ``True`` and ``False`` elements of which
         elements of the full catalogue, in ``con_cat_astro.npy``, are in ``a``.
@@ -548,7 +535,7 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     lon1, lon2, lat1, lat2 = sky_rect_coords
 
     sky_cut = _load_rectangular_slice(joint_folder_path, cat_name, a, lon1, lon2,
-                                      lat1, lat2, padding, memmap_slice_arrays)
+                                      lat1, lat2, padding)
 
     a_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path),
                        mmap_mode='r')[large_sky_slice][sky_cut]

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -273,8 +273,8 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
     print("Cleaning overlaps...")
     sys.stdout.flush()
 
-    ainds, asize = _clean_overlaps(ainds, asize, joint_folder_path, 'ainds', n_pool)
-    binds, bsize = _clean_overlaps(binds, bsize, joint_folder_path, 'binds', n_pool)
+    ainds, asize = _clean_overlaps(ainds, asize, n_pool)
+    binds, bsize = _clean_overlaps(binds, bsize, n_pool)
 
     print("Calculating integral lengths...")
     sys.stdout.flush()
@@ -294,8 +294,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             a_size_small = asize[lowind:highind]
             a_inds_small = np.asfortranarray(a_inds_small[:np.amax(a_size_small), :])
 
-            a_inds_map, a_inds_unique = map_large_index_to_small_index(
-                a_inds_small, len(b_full), '{}/group'.format(joint_folder_path))
+            a_inds_map, a_inds_unique = map_large_index_to_small_index(a_inds_small, len(b_full))
 
             b = b_full[a_inds_unique, 2]
 
@@ -322,8 +321,7 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
             b_size_small = bsize[lowind:highind]
             b_inds_small = np.asfortranarray(b_inds_small[:np.amax(b_size_small), :])
 
-            b_inds_map, b_inds_unique = map_large_index_to_small_index(
-                b_inds_small, len(a_full), '{}/group'.format(joint_folder_path))
+            b_inds_map, b_inds_unique = map_large_index_to_small_index(b_inds_small, len(a_full))
 
             a = a_full[b_inds_unique, 2]
 
@@ -563,7 +561,7 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
     return a_cutout, fouriergrid, modrefindsmall, sky_cut
 
 
-def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool):
+def _clean_overlaps(inds, size, n_pool):
     '''
     Convenience function to parse either catalogue's indices array for
     duplicate references to the opposing array on a per-source basis,
@@ -577,11 +575,6 @@ def _clean_overlaps(inds, size, joint_folder_path, filename, n_pool):
     size : numpy.ndarray
         Array containing the number of overlaps between this catalogue and the
         opposing catalogue prior to duplication removal.
-    joint_folder_path : string
-        The top-level folder containing the "group" folder into which the
-        index arrays are saved.
-    filename : string
-        The name of the ``inds`` array saved to disk.
     n_pool : integer
         Number of multiprocessing threads to use.
 

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -145,24 +145,13 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                                                                ax1_sparse_loops[1:])):
         for j, (ax2_sparse_start, ax2_sparse_end) in enumerate(zip(ax2_sparse_loops[:-1],
                                                                    ax2_sparse_loops[1:])):
-            a_big_sky_cut = _load_rectangular_slice(
-                joint_folder_path, '', a_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, 0)
-            b_big_sky_cut = _load_rectangular_slice(
-                joint_folder_path, '', b_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, max_sep)
+            a_big_sky_cut = _load_rectangular_slice('', a_full, ax1_sparse_start, ax1_sparse_end,
+                                                    ax2_sparse_start, ax2_sparse_end, 0)
+            b_big_sky_cut = _load_rectangular_slice('', b_full, ax1_sparse_start, ax1_sparse_end,
+                                                    ax2_sparse_start, ax2_sparse_end, max_sep)
             a_cutout = a_full[a_big_sky_cut]
             b_cutout = b_full[b_big_sky_cut]
 
-            small_memmap_slice_arrays_a = []
-            small_memmap_slice_arrays_b = []
-            for _ in range(5):
-                small_memmap_slice_arrays_a.append(np.zeros(dtype=bool, shape=(len(a_cutout),)))
-                small_memmap_slice_arrays_b.append(np.zeros(dtype=bool, shape=(len(b_cutout),)))
-
-            # TODO: avoid np.arange by first iterating an np.sum(big_sky_cut)
-            # and pre-generating a memmapped sub-array, and looping over
-            # putting the correct indices into place.
             a_sky_inds = np.arange(0, len(a_full))[a_big_sky_cut]
             b_sky_inds = np.arange(0, len(b_full))[b_big_sky_cut]
             for ax1_start, ax1_end in zip(ax1_loops[i*ax1_skip:(i+1)*ax1_skip],
@@ -208,20 +197,12 @@ def make_island_groupings(joint_folder_path, a_cat_folder_path, b_cat_folder_pat
                                                                ax1_sparse_loops[1:])):
         for j, (ax2_sparse_start, ax2_sparse_end) in enumerate(zip(ax2_sparse_loops[:-1],
                                                                    ax2_sparse_loops[1:])):
-            a_big_sky_cut = _load_rectangular_slice(
-                joint_folder_path, '', a_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, 0)
-            b_big_sky_cut = _load_rectangular_slice(
-                joint_folder_path, '', b_full, ax1_sparse_start, ax1_sparse_end, ax2_sparse_start,
-                ax2_sparse_end, max_sep)
+            a_big_sky_cut = _load_rectangular_slice('', a_full, ax1_sparse_start, ax1_sparse_end,
+                                                    ax2_sparse_start, ax2_sparse_end, 0)
+            b_big_sky_cut = _load_rectangular_slice('', b_full, ax1_sparse_start, ax1_sparse_end,
+                                                    ax2_sparse_start, ax2_sparse_end, max_sep)
             a_cutout = a_full[a_big_sky_cut]
             b_cutout = b_full[b_big_sky_cut]
-
-            small_memmap_slice_arrays_a = []
-            small_memmap_slice_arrays_b = []
-            for _ in range(5):
-                small_memmap_slice_arrays_a.append(np.zeros(dtype=bool, shape=(len(a_cutout),)))
-                small_memmap_slice_arrays_b.append(np.zeros(dtype=bool, shape=(len(b_cutout),)))
 
             a_sky_inds = np.arange(0, len(a_full))[a_big_sky_cut]
             b_sky_inds = np.arange(0, len(b_full))[b_big_sky_cut]
@@ -532,8 +513,7 @@ def _load_fourier_grid_cutouts(a, sky_rect_coords, joint_folder_path, cat_folder
 
     lon1, lon2, lat1, lat2 = sky_rect_coords
 
-    sky_cut = _load_rectangular_slice(joint_folder_path, cat_name, a, lon1, lon2,
-                                      lat1, lat2, padding)
+    sky_cut = _load_rectangular_slice(cat_name, a, lon1, lon2, lat1, lat2, padding)
 
     a_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path),
                        mmap_mode='r')[large_sky_slice][sky_cut]
@@ -550,7 +530,7 @@ def _clean_overlaps(inds, size, n_pool):
     '''
     Convenience function to parse either catalogue's indices array for
     duplicate references to the opposing array on a per-source basis,
-    and filter duplications in the memmapped file.
+    and filter duplications.
 
     Parameters
     ----------

--- a/macauff/group_sources.py
+++ b/macauff/group_sources.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from .misc_functions import (load_small_ref_auf_grid, hav_dist_constant_lat,
                              map_large_index_to_small_index, _load_rectangular_slice,
-                             _create_rectangular_slice_arrays, StageData)
+                             StageData)
 from .group_sources_fortran import group_sources_fortran as gsf
 from .make_set_list import set_list
 

--- a/macauff/make_set_list.py
+++ b/macauff/make_set_list.py
@@ -104,11 +104,11 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
                                                   'were', maxiters))
         sys.stdout.flush()
         rejectgroupnum = np.arange(1, groupmax+1)[grouplengthexceeded]
-        reject_a = np.arange(0, len(aoverlap))[np.in1d(agroup, rejectgroupnum)]
-        reject_b = np.arange(0, len(boverlap))[np.in1d(bgroup, rejectgroupnum)]
-        np.save('{}/reject/areject.npy'.format(joint_folder_path), reject_a)
-        np.save('{}/reject/breject.npy'.format(joint_folder_path), reject_b)
-        del reject_a, reject_b, rejectgroupnum
+        areject = np.arange(0, len(aoverlap))[np.in1d(agroup, rejectgroupnum)]
+        breject = np.arange(0, len(boverlap))[np.in1d(bgroup, rejectgroupnum)]
+        reject_flag = True
+    else:
+        reject_flag = False
 
     # Keep track of which sources have "good" group sizes, and the size of each
     # group in the two catalogues (e.g., group 1 has 2 "a" and 3 "b" sources).
@@ -177,7 +177,10 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
     agrouplengths = setdict["agrouplengths"]
     bgrouplengths = setdict["bgrouplengths"]
 
-    return alist, blist, agrouplengths, bgrouplengths
+    if reject_flag:
+        return alist, blist, agrouplengths, bgrouplengths, areject, breject
+    else:
+        return alist, blist, agrouplengths, bgrouplengths
 
 
 def _initial_group_numbering(aindices, bindices, aoverlap, boverlap, joint_folder_path):

--- a/macauff/make_set_list.py
+++ b/macauff/make_set_list.py
@@ -6,7 +6,6 @@ their respective uncertainties across two catalogues.
 '''
 
 import sys
-import os
 import warnings
 import multiprocessing
 import itertools

--- a/macauff/make_set_list.py
+++ b/macauff/make_set_list.py
@@ -118,9 +118,6 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
         goodlength[i:i+di] = np.logical_not(grouplengthexceeded[i:i+di])
     acounters = np.zeros(dtype=int, shape=(groupmax,))
     bcounters = np.zeros(dtype=int, shape=(groupmax,))
-    # open_memmap requires tuples of ints and np.amax doesn't play nicely with
-    # memmapped arrays, making (memmap(result)) variables, so we force the
-    # number to a simple int here.
     amaxlen, bmaxlen = 0, 0
     for i in range(0, len(agrouplengths), di):
         if np.sum(goodlength[i:i+di]) > 0:
@@ -145,7 +142,6 @@ def set_list(aindices, bindices, aoverlap, boverlap, joint_folder_path, n_pool):
     # list with islands too large to run.
     newsecondlen = 0
     for i in range(0, len(agrouplengths), di):
-        # Require the manual conversion to integer due to memmap issues again.
         newsecondlen += int(np.sum(goodlength[i:i+di]))
 
     di = max(1, newsecondlen // 20)

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -493,21 +493,20 @@ class CrossMatch():
         self._initialise_chunk(joint_file_path, cat_a_file_path, cat_b_file_path)
 
         # The first step is to create the perturbation AUF components, if needed.
-        # TODO: generalise the number of files per AUF simulation as input arg.
-        self.create_perturb_auf(7)
+        self.create_perturb_auf()
 
         # Once AUF components are assembled, we now group sources based on
         # convolved AUF integration lengths, to get "common overlap" sources
         # and merge such overlaps into distinct "islands" of sources to match.
-        self.group_sources(7)
+        self.group_sources()
 
         # The third step in this process is to, to some level, calculate the
         # photometry-related information necessary for the cross-match.
-        self.calculate_phot_like(5)
+        self.calculate_phot_like()
 
         # The final stage of the cross-match process is that of putting together
         # the previous stages, and calculating the cross-match probabilities.
-        self.pair_sources(13)
+        self.pair_sources()
 
         # Following cross-match completion, perform post-processing
         self._postprocess_chunk()
@@ -1435,14 +1434,12 @@ class CrossMatch():
         self.j0s = None
         self.j1s = None
 
-    def create_perturb_auf(self, files_per_auf_sim, perturb_auf_func=make_perturb_aufs):
+    def create_perturb_auf(self, perturb_auf_func=make_perturb_aufs):
         '''
         Function wrapping the main perturbation AUF component creation routines.
 
         Parameters
         ----------
-        files_per_auf_sim : integer
-            The number of output files for each individual perturbation simulation.
         perturb_auf_func : callable, optional
             ``perturb_auf_func`` should create the perturbation AUF output files
             for each filter-pointing combination.
@@ -1580,16 +1577,13 @@ class CrossMatch():
             self.b_auf_region_points, self.r, self.dr, self.rho, self.drho, 'b',
             self.include_perturb_auf, self.mem_chunk_num, **_kwargs)
 
-    def group_sources(self, files_per_grouping, group_func=make_island_groupings):
+    def group_sources(self, group_func=make_island_groupings):
         '''
         Function to handle the creation of catalogue "islands" and potential
         astrometrically related sources across the two catalogues.
 
         Parameters
         ----------
-        files_per_grouping : integer
-            The number of output files from each catalogue, made during the
-            island and overlap creation process.
         group_func : callable, optional
             ``group_func`` should create the various island- and overlap-related
             files by which objects across the two catalogues are assigned as
@@ -1612,16 +1606,13 @@ class CrossMatch():
                        self.mem_chunk_num, self.include_phot_like, self.use_phot_priors,
                        self.n_pool, self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)
 
-    def calculate_phot_like(self, files_per_phot, phot_like_func=compute_photometric_likelihoods):
+    def calculate_phot_like(self, phot_like_func=compute_photometric_likelihoods):
         '''
         Create the photometric likelihood information used in the cross-match
         process.
 
         Parameters
         ----------
-        files_per_phot : integer
-            The number of files created during the cross-match process for each
-            individual photometric sky position pointing.
         phot_like_func : callable, optional
             The function that calls the overall computation of the counterpart
             and "field" star photometric likelihood-related information.
@@ -1678,15 +1669,13 @@ class CrossMatch():
 
         return
 
-    def pair_sources(self, files_per_pairing, count_pair_func=source_pairing):
+    def pair_sources(self, count_pair_func=source_pairing):
         '''
         Assign sources in the two catalogues as either counterparts to one another
         or singly detected "field" sources.
 
         Parameters
         ----------
-        files_per_pairing : integer
-            The number of saved files expected in the pairing folder.
         count_pair_func : callable, optional
             The function that calls the counterpart determination routine.
         '''

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -1505,19 +1505,7 @@ class CrossMatch():
                                   'alpha_weight': self.gal_alphaweight})
             else:
                 _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})
-            if self.a_download_tri:
-                os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-            else:
-                for i in range(len(self.a_auf_region_points)):
-                    ax1, ax2 = self.a_auf_region_points[i]
-                    ax_folder = '{}/{}/{}'.format(self.a_auf_folder_path, ax1, ax2)
-                    os.system('mv {}/trilegal_auf_simulation_faint.dat {}/..'.format(
-                              ax_folder, ax_folder))
-                    os.system("rm -rf {}/*".format(ax_folder))
-                    os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
-                              ax_folder, ax_folder))
         else:
-            os.system("rm -rf {}/*".format(self.a_auf_folder_path))
             _kwargs = {}
         self.a_modelrefinds, self.a_perturb_auf_outputs = perturb_auf_func(
             self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
@@ -1558,19 +1546,7 @@ class CrossMatch():
                                   'alpha_weight': self.gal_alphaweight})
             else:
                 _kwargs = dict(_kwargs, **{'fit_gal_flag': self.b_fit_gal_flag})
-            if self.b_download_tri:
-                os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-            else:
-                for i in range(len(self.b_auf_region_points)):
-                    ax1, ax2 = self.b_auf_region_points[i]
-                    ax_folder = '{}/{}/{}'.format(self.b_auf_folder_path, ax1, ax2)
-                    os.system('mv {}/trilegal_auf_simulation_faint.dat {}/..'.format(
-                              ax_folder, ax_folder))
-                    os.system("rm -rf {}/*".format(ax_folder))
-                    os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
-                              ax_folder, ax_folder))
         else:
-            os.system("rm -rf {}/*".format(self.b_auf_folder_path))
             _kwargs = {}
         self.b_modelrefinds, self.b_perturb_auf_outputs = perturb_auf_func(
             self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -832,13 +832,7 @@ class CrossMatch():
         # However, calling AstrometricCorrections in its current form confuses
         # this, since it always uses the perturbation AUF component. We therefore
         # split out the items that are NOT required for AstrometricCorrections
-        # first.
-        if self.include_perturb_auf:
-            for check_flag in ['compute_local_density']:
-                if check_flag not in joint_config:
-                    raise ValueError("Missing key {} from joint metadata file.".format(check_flag))
-
-            self.compute_local_density = self._str2bool(joint_config['compute_local_density'])
+        # first, if there are any.
 
         self.a_correct_astrometry = self._str2bool(cat_a_config['correct_astrometry'])
         self.b_correct_astrometry = self._str2bool(cat_b_config['correct_astrometry'])
@@ -882,7 +876,7 @@ class CrossMatch():
                 [self.a_correct_astrometry, self.b_correct_astrometry],
                 [self.a_compute_snr_mag_relation, self.b_compute_snr_mag_relation],
                 [cat_a_config, cat_b_config], ['"a"', '"b"'], ['a_', 'b_']):
-            if (self.include_perturb_auf and self.compute_local_density) or correct_astro:
+            if self.include_perturb_auf or correct_astro:
                 for check_flag in ['dens_dist']:
                     if check_flag not in config:
                         raise ValueError("Missing key {} from catalogue {} metadata file."
@@ -1500,8 +1494,8 @@ class CrossMatch():
             _kwargs = {'psf_fwhms': self.a_psf_fwhms, 'tri_download_flag': self.a_download_tri,
                        'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
                        'j0s': self.j0s, 'd_mag': self.d_mag,
+                       'density_radius': self.a_dens_dist,
                        'tri_filt_names': self.a_tri_filt_names,
-                       'compute_local_density': self.compute_local_density,
                        'run_fw': self.a_run_fw_auf, 'run_psf': self.a_run_psf_auf,
                        'snr_mag_params': self.a_snr_mag_params,
                        'tri_maglim_faint': self.a_tri_maglim_faint,
@@ -1534,8 +1528,6 @@ class CrossMatch():
                     os.system("rm -rf {}/*".format(ax_folder))
                     os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
                               ax_folder, ax_folder))
-            if self.compute_local_density:
-                _kwargs = dict(_kwargs, **{'density_radius': self.a_dens_dist})
         else:
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
             _kwargs = {}
@@ -1554,8 +1546,8 @@ class CrossMatch():
             _kwargs = {'psf_fwhms': self.b_psf_fwhms, 'tri_download_flag': self.b_download_tri,
                        'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
                        'j0s': self.j0s, 'd_mag': self.d_mag,
+                       'density_radius': self.b_dens_dist,
                        'tri_filt_names': self.b_tri_filt_names,
-                       'compute_local_density': self.compute_local_density,
                        'run_fw': self.b_run_fw_auf, 'run_psf': self.b_run_psf_auf,
                        'snr_mag_params': self.b_snr_mag_params,
                        'tri_maglim_faint': self.b_tri_maglim_faint,
@@ -1589,8 +1581,6 @@ class CrossMatch():
                     os.system("rm -rf {}/*".format(ax_folder))
                     os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
                               ax_folder, ax_folder))
-            if self.compute_local_density:
-                _kwargs = dict(_kwargs, **{'density_radius': self.b_dens_dist})
         else:
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
             _kwargs = {}

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -38,10 +38,6 @@ class CrossMatch():
     ----------
     chunks_folder_path : string
         A path to the location of the folder containing one subfolder per chunk.
-    use_memmap_files : boolean
-        When set to True, memory mapped files are used for several internal
-        arrays. Reduces memory consumption bottlenecks at the cost of increased
-        I/O contention.
     resume_file_path : string, optional
         A path to the location of the file containing resume information for the
         cross match.
@@ -58,13 +54,12 @@ class CrossMatch():
         monitors walltime. Default is 1 second.
     '''
 
-    def __init__(self, chunks_folder_path, use_memmap_files=False, resume_file_path=None,
-                 use_mpi=True, walltime=None, end_within='00:10:00', polling_rate=1):
+    def __init__(self, chunks_folder_path, resume_file_path=None, use_mpi=True, walltime=None,
+                 end_within='00:10:00', polling_rate=1):
         '''
         Initialisation function for cross-match class.
         '''
         self.chunks_folder_path = chunks_folder_path
-        self.use_memmap_files = use_memmap_files
 
         # Initialise MPI if available and enabled
         if MPI != None and use_mpi:
@@ -292,23 +287,6 @@ class CrossMatch():
                 raise ValueError('b_snr_mag_params should be of shape (X, Y, 5)')
             self.b_snr_mag_params = a
 
-        # Important steps that can be save points in the match process are:
-        # AUF creation, island splitting, c/f creation, star pairing. We have
-        # to check if any later stages are flagged to not run (i.e., they are
-        # the starting point) than earlier stages, and raise an error.
-        flags = np.array([self.run_auf, self.run_group, self.run_cf, self.run_source])
-        for i in range(3):
-            if flags[i] and np.any(~flags[i+1:]):
-                raise ValueError("Inconsistency between run/no run flags; please ensure that "
-                                 "if a sub-process is set to run that all subsequent "
-                                 "processes are also set to run.")
-        if not self.use_memmap_files and np.any(~flags):
-            warnings.warn("use_memmap_files is False but one or more of run_auf, run_group, "
-                          "run_cf, or run_source were set to False. These must all be run if "
-                          "save states are not saved, please double check which is the preferred "
-                          "option. Setting run flags all to True.")
-            self.run_auf, self.run_group, self.run_cf, self.run_source = True, True, True, True
-
         # Ensure that we can create the folders for outputs.
         for path in ['group', 'reject', 'phot_like', 'pairing']:
             try:
@@ -370,13 +348,6 @@ class CrossMatch():
             except OSError:
                 raise OSError("Error when trying to create temporary folder for catalogue-level "
                               "outputs. Please ensure that catalogue folder names are correct.")
-
-        if self.include_perturb_auf:
-            for tri_flag, catname in zip([self.a_download_tri, self.b_download_tri], ['a_', 'b_']):
-                if tri_flag and not self.run_auf:
-                    raise ValueError("{}download_tri is True and run_auf is False. Please ensure "
-                                     "that run_auf is True if new TRILEGAL simulations are to be "
-                                     "downloaded.".format(catname))
 
         self.make_shared_data()
 
@@ -531,8 +502,6 @@ class CrossMatch():
         self._initialise_chunk(joint_file_path, cat_a_file_path, cat_b_file_path)
 
         # The first step is to create the perturbation AUF components, if needed.
-        # If run_auf is set to True or if there are not the appropriate number of
-        # pre-saved outputs from a previous run then run perturbation AUF creation.
         # TODO: generalise the number of files per AUF simulation as input arg.
         self.create_perturb_auf(7)
 
@@ -567,158 +536,36 @@ class CrossMatch():
         print("{} Rank {}, chunk {}: Removing halo matches and non-matches..."
               .format(t, self.rank, self.chunk_id))
 
-        if self.use_memmap_files:
-            _kwargs = {'mmap_mode': 'r'}
-        else:
-            _kwargs = {}
-        ac = np.load('{}/pairing/ac.npy'.format(self.joint_folder_path), **_kwargs)
-        bc = np.load('{}/pairing/bc.npy'.format(self.joint_folder_path), **_kwargs)
+        ac = np.load('{}/pairing/ac.npy'.format(self.joint_folder_path))
+        bc = np.load('{}/pairing/bc.npy'.format(self.joint_folder_path))
 
-        af = np.load('{}/pairing/af.npy'.format(self.joint_folder_path), **_kwargs)
-        bf = np.load('{}/pairing/bf.npy'.format(self.joint_folder_path), **_kwargs)
+        af = np.load('{}/pairing/af.npy'.format(self.joint_folder_path))
+        bf = np.load('{}/pairing/bf.npy'.format(self.joint_folder_path))
 
-        a_in_overlaps = np.load('{}/in_chunk_overlap.npy'.format(self.a_cat_folder_path), **_kwargs)
-        b_in_overlaps = np.load('{}/in_chunk_overlap.npy'.format(self.b_cat_folder_path), **_kwargs)
+        a_in_overlaps = np.load('{}/in_chunk_overlap.npy'.format(self.a_cat_folder_path))
+        b_in_overlaps = np.load('{}/in_chunk_overlap.npy'.format(self.b_cat_folder_path))
 
-        if self.use_memmap_files:
-            # Do core_matches = ~a_in_overlaps[ac] | ~b_in_overlaps[bc] but in memmap
-            core_matches = np.lib.format.open_memmap(
-                '{}/pairing/core_matches.npy'.format(self.joint_folder_path),
-                mode='w+', dtype=bool, shape=(len(ac),))
+        core_matches = ~a_in_overlaps[ac] | ~b_in_overlaps[bc]
+        np.save('{}/pairing/ac.npy'.format(self.joint_folder_path), ac[core_matches])
+        np.save('{}/pairing/bc.npy'.format(self.joint_folder_path), bc[core_matches])
+        for fname in ['pc', 'eta', 'xi', 'crptseps', 'acontamflux', 'bcontamflux']:
+            np.save('{}/pairing/{}.npy'.format(self.joint_folder_path, fname),
+                    np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname))[
+                        core_matches])
+        for fname in ['pacontam', 'pbcontam']:
+            np.save('{}/pairing/{}.npy'.format(self.joint_folder_path, fname),
+                    np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname))[
+                        :, core_matches])
 
-            di = max(1, len(ac) // 20)
-            for i in range(0, len(ac), di):
-                core_matches[i:i+di] = ~a_in_overlaps[ac[i:i+di]] | ~b_in_overlaps[bc[i:i+di]]
-
-            di = max(1, len(core_matches) // 20)
-            new_c_length = 0
-            for i in range(0, len(core_matches), di):
-                # Require the manual conversion to integer due to memmap issues.
-                new_c_length += int(np.sum(core_matches[i:i+di]))
-
-            for cat_kind, c in zip(['a', 'b'], [ac, bc]):
-                new_c = np.lib.format.open_memmap(
-                    '{}/pairing/{}c2.npy'.format(self.joint_folder_path, cat_kind),
-                    mode='w+', dtype=int, shape=(new_c_length,))
-                tick = 0
-                for i in range(0, len(c), di):
-                    new_c[tick:tick+np.sum(core_matches[i:i+di])] = c[i:i+di][core_matches[i:i+di]]
-                    tick += np.sum(core_matches[i:i+di])
-                os.system('mv {}/pairing/{}c2.npy {}/pairing/{}c.npy'.format(
-                          self.joint_folder_path, cat_kind, self.joint_folder_path, cat_kind))
-
-                # While within the a-b loop, also want to loop over the extra
-                # things that need updating: *confamflux, p*contam
-                for fname in ['{}contamflux', 'p{}contam']:
-                    new_name = fname.format(cat_kind)
-                    old_c = np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, new_name),
-                                    **_kwargs)
-                    shape = (new_c_length,) if len(old_c.shape) == 1 else (
-                        old_c.shape[0], new_c_length)
-                    new_c = np.lib.format.open_memmap(
-                        '{}/pairing/{}2.npy'.format(self.joint_folder_path, new_name),
-                        mode='w+', dtype=float, shape=shape)
-                    tick = 0
-                    for i in range(0, len(c), di):
-                        if 'flux' in fname:
-                            new_c[tick:tick+np.sum(core_matches[i:i+di])] = old_c[i:i+di][
-                                core_matches[i:i+di]]
-                        else:
-                            new_c[:, tick:tick+np.sum(core_matches[i:i+di])] = old_c[:, i:i+di][
-                                :, core_matches[i:i+di]]
-                        tick += np.sum(core_matches[i:i+di])
-                    os.system('mv {}/pairing/{}2.npy {}/pairing/{}.npy'.format(
-                              self.joint_folder_path, new_name, self.joint_folder_path, new_name))
-            # Outside of the a-b loop, update shared common items: pc, eta,
-            # xi, sep.
-            for fname in ['pc', 'eta', 'xi', 'crptseps']:
-                old_c = np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname),
-                                **_kwargs)
-                new_c = np.lib.format.open_memmap(
-                    '{}/pairing/{}2.npy'.format(self.joint_folder_path, fname),
-                    mode='w+', dtype=float, shape=(new_c_length,))
-                tick = 0
-                for i in range(0, len(c), di):
-                    new_c[tick:tick+np.sum(core_matches[i:i+di])] = old_c[i:i+di][
-                        core_matches[i:i+di]]
-                    tick += np.sum(core_matches[i:i+di])
-                os.system('mv {}/pairing/{}2.npy {}/pairing/{}.npy'.format(
-                          self.joint_folder_path, fname, self.joint_folder_path, fname))
-            os.remove('{}/pairing/core_matches.npy'.format(self.joint_folder_path))
-        else:
-            core_matches = ~a_in_overlaps[ac] | ~b_in_overlaps[bc]
-            np.save('{}/pairing/ac.npy'.format(self.joint_folder_path), ac[core_matches])
-            np.save('{}/pairing/bc.npy'.format(self.joint_folder_path), bc[core_matches])
-            for fname in ['pc', 'eta', 'xi', 'crptseps', 'acontamflux', 'bcontamflux']:
+        a_core_nonmatches = ~a_in_overlaps[af]
+        b_core_nonmatches = ~b_in_overlaps[bf]
+        np.save('{}/pairing/af.npy'.format(self.joint_folder_path), af[a_core_nonmatches])
+        np.save('{}/pairing/bf.npy'.format(self.joint_folder_path), bf[b_core_nonmatches])
+        for fnametype, cnm in zip(['a', 'b'], [a_core_nonmatches, b_core_nonmatches]):
+            for fname_ in ['{}fieldflux', 'pf{}', '{}fieldeta', '{}fieldxi', '{}fieldseps']:
+                fname = fname_.format(fnametype)
                 np.save('{}/pairing/{}.npy'.format(self.joint_folder_path, fname),
-                        np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname))[
-                            core_matches])
-            for fname in ['pacontam', 'pbcontam']:
-                np.save('{}/pairing/{}.npy'.format(self.joint_folder_path, fname),
-                        np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname))[
-                            :, core_matches])
-
-        if self.use_memmap_files:
-            # Do a_core_nonmatches = ~a_in_overlaps[af] but in memmap
-            a_core_nonmatches = np.lib.format.open_memmap(
-                '{}/pairing/a_core_nonmatches.npy'.format(self.joint_folder_path),
-                mode='w+', dtype=bool, shape=(len(af),))
-            b_core_nonmatches = np.lib.format.open_memmap(
-                '{}/pairing/b_core_nonmatches.npy'.format(self.joint_folder_path),
-                mode='w+', dtype=bool, shape=(len(bf),))
-
-            di = max(1, len(af) // 20)
-            for i in range(0, len(af), di):
-                a_core_nonmatches[i:i+di] = ~a_in_overlaps[af[i:i+di]]
-
-            di = max(1, len(bf) // 20)
-            for i in range(0, len(bf), di):
-                b_core_nonmatches[i:i+di] = ~b_in_overlaps[bf[i:i+di]]
-
-            for cat_kind, f, cnm in zip(['a', 'b'], [af, bf],
-                                        [a_core_nonmatches, b_core_nonmatches]):
-                di = max(1, len(cnm) // 20)
-                new_f_length = 0
-                for i in range(0, len(cnm), di):
-                    # Require the manual conversion to integer due to memmap issues.
-                    new_f_length += int(np.sum(cnm[i:i+di]))
-                new_f = np.lib.format.open_memmap(
-                    '{}/pairing/{}f2.npy'.format(self.joint_folder_path, cat_kind),
-                    mode='w+', dtype=int, shape=(new_f_length,))
-                tick = 0
-                for i in range(0, len(f), di):
-                    new_f[tick:tick+np.sum(cnm[i:i+di])] = f[i:i+di][cnm[i:i+di]]
-                    tick += np.sum(cnm[i:i+di])
-                os.system('mv {}/pairing/{}f2.npy {}/pairing/{}f.npy'.format(
-                          self.joint_folder_path, cat_kind, self.joint_folder_path, cat_kind))
-
-                # This time all "other" files are also a-b specific.
-                for fname in ['{}fieldflux', 'pf{}', '{}fieldeta', '{}fieldxi', '{}fieldseps']:
-                    new_name = fname.format(cat_kind)
-                    old_f = np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, new_name),
-                                    **_kwargs)
-                    new_f = np.lib.format.open_memmap(
-                        '{}/pairing/{}2.npy'.format(self.joint_folder_path, new_name),
-                        mode='w+', dtype=float, shape=(new_f_length,))
-                    tick = 0
-                    for i in range(0, len(cnm), di):
-                        new_f[tick:tick+np.sum(cnm[i:i+di])] = old_f[i:i+di][cnm[i:i+di]]
-                        tick += np.sum(cnm[i:i+di])
-                    os.system('mv {}/pairing/{}2.npy {}/pairing/{}.npy'.format(
-                              self.joint_folder_path, new_name, self.joint_folder_path, new_name))
-
-            os.remove('{}/pairing/a_core_nonmatches.npy'.format(self.joint_folder_path))
-            os.remove('{}/pairing/b_core_nonmatches.npy'.format(self.joint_folder_path))
-        else:
-            a_core_nonmatches = ~a_in_overlaps[af]
-            b_core_nonmatches = ~b_in_overlaps[bf]
-            np.save('{}/pairing/af.npy'.format(self.joint_folder_path), af[a_core_nonmatches])
-            np.save('{}/pairing/bf.npy'.format(self.joint_folder_path), bf[b_core_nonmatches])
-            for fnametype, cnm in zip(['a', 'b'], [a_core_nonmatches, b_core_nonmatches]):
-                for fname_ in ['{}fieldflux', 'pf{}', '{}fieldeta', '{}fieldxi', '{}fieldseps']:
-                    fname = fname_.format(fnametype)
-                    np.save('{}/pairing/{}.npy'.format(self.joint_folder_path, fname),
-                            np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname))[cnm])
+                        np.load('{}/pairing/{}.npy'.format(self.joint_folder_path, fname))[cnm])
 
         if self.make_output_csv:
             npy_to_csv(
@@ -933,12 +780,11 @@ class CrossMatch():
             cat_b_config.read_string('[config]\n' + f.read())
         cat_b_config = cat_b_config['config']
 
-        for check_flag in ['include_perturb_auf', 'include_phot_like', 'run_auf', 'run_group',
-                           'run_cf', 'run_source', 'use_phot_priors', 'cf_region_type',
-                           'cf_region_frame', 'cf_region_points', 'joint_folder_path',
-                           'pos_corr_dist', 'real_hankel_points', 'four_hankel_points',
-                           'four_max_rho', 'cross_match_extent', 'mem_chunk_num', 'int_fracs',
-                           'make_output_csv', 'n_pool']:
+        for check_flag in ['include_perturb_auf', 'include_phot_like', 'use_phot_priors',
+                           'cf_region_type', 'cf_region_frame', 'cf_region_points',
+                           'joint_folder_path', 'pos_corr_dist', 'real_hankel_points',
+                           'four_hankel_points', 'four_max_rho', 'cross_match_extent',
+                           'mem_chunk_num', 'int_fracs', 'make_output_csv', 'n_pool']:
             if check_flag not in joint_config:
                 raise ValueError("Missing key {} from joint metadata file.".format(check_flag))
 
@@ -950,8 +796,7 @@ class CrossMatch():
                     raise ValueError("Missing key {} from catalogue {} metadata file.".format(
                                      check_flag, catname))
 
-        for run_flag in ['include_perturb_auf', 'include_phot_like', 'run_auf', 'run_group',
-                         'run_cf', 'run_source', 'use_phot_priors']:
+        for run_flag in ['include_perturb_auf', 'include_phot_like', 'use_phot_priors']:
             setattr(self, run_flag, self._str2bool(joint_config[run_flag]))
 
         for config, catname in zip([cat_a_config, cat_b_config], ['a_', 'b_']):
@@ -1617,19 +1462,6 @@ class CrossMatch():
             ``perturb_auf_func`` should create the perturbation AUF output files
             for each filter-pointing combination.
         '''
-        # Each catalogue has in its auf_folder_path a single file, a local
-        # normalising density, plus -- per AUF "pointing" -- a simulation file
-        # and N simulation files per filter. Additionally, it will contain a
-        # single file with each source's index reference into the cube of AUFs,
-        # and a convenience cube for each N-m combination array's length; it will
-        # also contain 3- and 4-D cubes of the fourier-space perturbation AUF
-        # component, and simulated flux contamination and fraction of contaminated
-        # sources, for all simulations.
-        a_expected_files = 6 + len(self.a_auf_region_points) + (
-            files_per_auf_sim * len(self.a_filt_names) * len(self.a_auf_region_points))
-        a_file_number = np.sum([len(files) for _, _, files in
-                                os.walk(self.a_auf_folder_path)])
-        a_correct_file_number = a_expected_files == a_file_number
 
         # Magnitude offsets corresponding to relative fluxes of perturbing sources; here
         # dm of 2.5 is 10% relative flux and dm = 5 corresponds to 1% relative flux. Used
@@ -1658,149 +1490,115 @@ class CrossMatch():
         self.gal_alphaweight = [[3.47e+09, 3.31e+06, 2.13e+09, 1.64e+10, 1.01e+09],
                                 [3.84e+09, 1.57e+06, 3.91e+08, 4.66e+10, 3.03e+07]]
 
-        if self.run_auf or not a_correct_file_number:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Creating empirical perturbation AUFs for catalogue "a"...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            if self.j0s is None:
-                self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
-            # Only warn if we did NOT choose to run AUF, but DID hit wrong file
-            # number.
-            if not a_correct_file_number and not self.run_auf:
-                warnings.warn('Rank {}, chunk {}: Incorrect number of files in catalogue "a" '
-                              'perturbation AUF simulation folder. Deleting all files and '
-                              're-running cross-match process.'.format(self.rank, self.chunk_id))
-                # Once run AUF flag is updated, all other flags need to be set to run
-                self.run_group, self.run_cf, self.run_source = True, True, True
-            if self.include_perturb_auf:
-                _kwargs = {'psf_fwhms': self.a_psf_fwhms, 'tri_download_flag': self.a_download_tri,
-                           'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
-                           'j0s': self.j0s, 'd_mag': self.d_mag,
-                           'tri_filt_names': self.a_tri_filt_names,
-                           'compute_local_density': self.compute_local_density,
-                           'run_fw': self.a_run_fw_auf, 'run_psf': self.a_run_psf_auf,
-                           'snr_mag_params': self.a_snr_mag_params,
-                           'tri_maglim_faint': self.a_tri_maglim_faint,
-                           'tri_num_faint': self.a_tri_num_faint,
-                           'tri_set_name': self.a_tri_set_name,
-                           'tri_filt_num': self.a_tri_filt_num,
-                           'auf_region_frame': self.a_auf_region_frame,
-                           'al_avs': self.a_gal_al_avs, 'fit_gal_flag': self.a_fit_gal_flag}
-                if self.a_run_psf_auf:
-                    _kwargs = dict(_kwargs, **{'dd_params': self.a_dd_params,
-                                               'l_cut': self.a_l_cut})
-                if self.a_fit_gal_flag:
-                    _kwargs = dict(_kwargs,
-                                   **{'cmau_array': self.gal_cmau_array, 'wavs': self.a_gal_wavs,
-                                      'z_maxs': self.a_gal_zmax, 'nzs': self.a_gal_nzs,
-                                      'ab_offsets': self.a_gal_aboffsets,
-                                      'filter_names': self.a_gal_filternames,
-                                      'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
-                                      'alpha_weight': self.gal_alphaweight})
-                else:
-                    _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})
-                if self.a_download_tri:
-                    os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-                else:
-                    for i in range(len(self.a_auf_region_points)):
-                        ax1, ax2 = self.a_auf_region_points[i]
-                        ax_folder = '{}/{}/{}'.format(self.a_auf_folder_path, ax1, ax2)
-                        os.system('mv {}/trilegal_auf_simulation_faint.dat {}/..'.format(
-                                  ax_folder, ax_folder))
-                        os.system("rm -rf {}/*".format(ax_folder))
-                        os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
-                                  ax_folder, ax_folder))
-                if self.compute_local_density:
-                    _kwargs = dict(_kwargs, **{'density_radius': self.a_dens_dist})
+        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print('{} Rank {}, chunk {}: Creating empirical perturbation AUFs for catalogue "a"...'
+              .format(t, self.rank, self.chunk_id))
+        sys.stdout.flush()
+        if self.j0s is None:
+            self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
+        if self.include_perturb_auf:
+            _kwargs = {'psf_fwhms': self.a_psf_fwhms, 'tri_download_flag': self.a_download_tri,
+                       'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
+                       'j0s': self.j0s, 'd_mag': self.d_mag,
+                       'tri_filt_names': self.a_tri_filt_names,
+                       'compute_local_density': self.compute_local_density,
+                       'run_fw': self.a_run_fw_auf, 'run_psf': self.a_run_psf_auf,
+                       'snr_mag_params': self.a_snr_mag_params,
+                       'tri_maglim_faint': self.a_tri_maglim_faint,
+                       'tri_num_faint': self.a_tri_num_faint,
+                       'tri_set_name': self.a_tri_set_name,
+                       'tri_filt_num': self.a_tri_filt_num,
+                       'auf_region_frame': self.a_auf_region_frame,
+                       'al_avs': self.a_gal_al_avs, 'fit_gal_flag': self.a_fit_gal_flag}
+            if self.a_run_psf_auf:
+                _kwargs = dict(_kwargs, **{'dd_params': self.a_dd_params,
+                                           'l_cut': self.a_l_cut})
+            if self.a_fit_gal_flag:
+                _kwargs = dict(_kwargs,
+                               **{'cmau_array': self.gal_cmau_array, 'wavs': self.a_gal_wavs,
+                                  'z_maxs': self.a_gal_zmax, 'nzs': self.a_gal_nzs,
+                                  'ab_offsets': self.a_gal_aboffsets,
+                                  'filter_names': self.a_gal_filternames,
+                                  'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
+                                  'alpha_weight': self.gal_alphaweight})
             else:
+                _kwargs = dict(_kwargs, **{'fit_gal_flag': self.a_fit_gal_flag})
+            if self.a_download_tri:
                 os.system("rm -rf {}/*".format(self.a_auf_folder_path))
-                _kwargs = {}
-            self.a_modelrefinds = perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
-                                                   self.a_auf_region_points, self.r, self.dr,
-                                                   self.rho, self.drho, 'a', self.include_perturb_auf,
-                                                   self.mem_chunk_num, self.use_memmap_files, **_kwargs)
-        else:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Loading empirical perturbation AUFs for catalogue "a"...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            self.a_modelrefinds = np.load('{}/modelrefinds.npy'.format(self.a_auf_folder_path),
-                                          mmap_mode='r')
-
-        b_expected_files = 6 + len(self.b_auf_region_points) + (
-            files_per_auf_sim * len(self.b_filt_names) * len(self.b_auf_region_points))
-        b_file_number = np.sum([len(files) for _, _, files in
-                                os.walk(self.b_auf_folder_path)])
-        b_correct_file_number = b_expected_files == b_file_number
-
-        if self.run_auf or not b_correct_file_number:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Creating empirical perturbation AUFs for catalogue "b"...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            if self.j0s is None:
-                self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
-            if not b_correct_file_number and not self.run_auf:
-                warnings.warn('Rank {}, chunk {}: Incorrect number of files in catalogue "b" '
-                              'perturbation AUF simulation folder. Deleting all files and '
-                              're-running cross-match process.'.format(self.rank, self.chunk_id))
-                self.run_group, self.run_cf, self.run_source = True, True, True
-            if self.include_perturb_auf:
-                _kwargs = {'psf_fwhms': self.b_psf_fwhms, 'tri_download_flag': self.b_download_tri,
-                           'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
-                           'j0s': self.j0s, 'd_mag': self.d_mag,
-                           'tri_filt_names': self.b_tri_filt_names,
-                           'compute_local_density': self.compute_local_density,
-                           'run_fw': self.b_run_fw_auf, 'run_psf': self.b_run_psf_auf,
-                           'snr_mag_params': self.b_snr_mag_params,
-                           'tri_maglim_faint': self.b_tri_maglim_faint,
-                           'tri_num_faint': self.b_tri_num_faint,
-                           'tri_set_name': self.b_tri_set_name,
-                           'tri_filt_num': self.b_tri_filt_num,
-                           'auf_region_frame': self.b_auf_region_frame,
-                           'al_avs': self.b_gal_al_avs, 'fit_gal_flag': self.b_fit_gal_flag}
-                if self.b_run_psf_auf:
-                    _kwargs = dict(_kwargs, **{'dd_params': self.b_dd_params,
-                                               'l_cut': self.b_l_cut})
-
-                if self.b_fit_gal_flag:
-                    _kwargs = dict(_kwargs,
-                                   **{'cmau_array': self.gal_cmau_array, 'wavs': self.b_gal_wavs,
-                                      'z_maxs': self.b_gal_zmax, 'nzs': self.b_gal_nzs,
-                                      'ab_offsets': self.b_gal_aboffsets,
-                                      'filter_names': self.b_gal_filternames,
-                                      'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
-                                      'alpha_weight': self.gal_alphaweight})
-                else:
-                    _kwargs = dict(_kwargs, **{'fit_gal_flag': self.b_fit_gal_flag})
-                if self.b_download_tri:
-                    os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-                else:
-                    for i in range(len(self.b_auf_region_points)):
-                        ax1, ax2 = self.b_auf_region_points[i]
-                        ax_folder = '{}/{}/{}'.format(self.b_auf_folder_path, ax1, ax2)
-                        os.system('mv {}/trilegal_auf_simulation_faint.dat {}/..'.format(
-                                  ax_folder, ax_folder))
-                        os.system("rm -rf {}/*".format(ax_folder))
-                        os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
-                                  ax_folder, ax_folder))
-                if self.compute_local_density:
-                    _kwargs = dict(_kwargs, **{'density_radius': self.b_dens_dist})
             else:
-                os.system("rm -rf {}/*".format(self.b_auf_folder_path))
-                _kwargs = {}
-            self.b_modelrefinds = perturb_auf_func(self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
-                                                   self.b_auf_region_points, self.r, self.dr,
-                                                   self.rho, self.drho, 'b', self.include_perturb_auf,
-                                                   self.mem_chunk_num, self.use_memmap_files, **_kwargs)
+                for i in range(len(self.a_auf_region_points)):
+                    ax1, ax2 = self.a_auf_region_points[i]
+                    ax_folder = '{}/{}/{}'.format(self.a_auf_folder_path, ax1, ax2)
+                    os.system('mv {}/trilegal_auf_simulation_faint.dat {}/..'.format(
+                              ax_folder, ax_folder))
+                    os.system("rm -rf {}/*".format(ax_folder))
+                    os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
+                              ax_folder, ax_folder))
+            if self.compute_local_density:
+                _kwargs = dict(_kwargs, **{'density_radius': self.a_dens_dist})
         else:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Loading empirical perturbation AUFs for catalogue "b"...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            self.b_modelrefinds = np.load('{}/modelrefinds.npy'.format(self.b_auf_folder_path),
-                                          mmap_mode='r')
+            os.system("rm -rf {}/*".format(self.a_auf_folder_path))
+            _kwargs = {}
+        self.a_modelrefinds = perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
+                                               self.a_auf_region_points, self.r, self.dr,
+                                               self.rho, self.drho, 'a', self.include_perturb_auf,
+                                               self.mem_chunk_num, **_kwargs)
+
+        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print('{} Rank {}, chunk {}: Creating empirical perturbation AUFs for catalogue "b"...'
+              .format(t, self.rank, self.chunk_id))
+        sys.stdout.flush()
+        if self.j0s is None:
+            self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
+        if self.include_perturb_auf:
+            _kwargs = {'psf_fwhms': self.b_psf_fwhms, 'tri_download_flag': self.b_download_tri,
+                       'delta_mag_cuts': self.delta_mag_cuts, 'num_trials': self.num_trials,
+                       'j0s': self.j0s, 'd_mag': self.d_mag,
+                       'tri_filt_names': self.b_tri_filt_names,
+                       'compute_local_density': self.compute_local_density,
+                       'run_fw': self.b_run_fw_auf, 'run_psf': self.b_run_psf_auf,
+                       'snr_mag_params': self.b_snr_mag_params,
+                       'tri_maglim_faint': self.b_tri_maglim_faint,
+                       'tri_num_faint': self.b_tri_num_faint,
+                       'tri_set_name': self.b_tri_set_name,
+                       'tri_filt_num': self.b_tri_filt_num,
+                       'auf_region_frame': self.b_auf_region_frame,
+                       'al_avs': self.b_gal_al_avs, 'fit_gal_flag': self.b_fit_gal_flag}
+            if self.b_run_psf_auf:
+                _kwargs = dict(_kwargs, **{'dd_params': self.b_dd_params,
+                                           'l_cut': self.b_l_cut})
+
+            if self.b_fit_gal_flag:
+                _kwargs = dict(_kwargs,
+                               **{'cmau_array': self.gal_cmau_array, 'wavs': self.b_gal_wavs,
+                                  'z_maxs': self.b_gal_zmax, 'nzs': self.b_gal_nzs,
+                                  'ab_offsets': self.b_gal_aboffsets,
+                                  'filter_names': self.b_gal_filternames,
+                                  'alpha0': self.gal_alpha0, 'alpha1': self.gal_alpha1,
+                                  'alpha_weight': self.gal_alphaweight})
+            else:
+                _kwargs = dict(_kwargs, **{'fit_gal_flag': self.b_fit_gal_flag})
+            if self.b_download_tri:
+                os.system("rm -rf {}/*".format(self.b_auf_folder_path))
+            else:
+                for i in range(len(self.b_auf_region_points)):
+                    ax1, ax2 = self.b_auf_region_points[i]
+                    ax_folder = '{}/{}/{}'.format(self.b_auf_folder_path, ax1, ax2)
+                    os.system('mv {}/trilegal_auf_simulation_faint.dat {}/..'.format(
+                              ax_folder, ax_folder))
+                    os.system("rm -rf {}/*".format(ax_folder))
+                    os.system('mv {}/../trilegal_auf_simulation_faint.dat {}'.format(
+                              ax_folder, ax_folder))
+            if self.compute_local_density:
+                _kwargs = dict(_kwargs, **{'density_radius': self.b_dens_dist})
+        else:
+            os.system("rm -rf {}/*".format(self.b_auf_folder_path))
+            _kwargs = {}
+        self.b_modelrefinds = perturb_auf_func(self.b_auf_folder_path, self.b_cat_folder_path,
+                                               self.b_filt_names, self.b_auf_region_points, self.r,
+                                               self.dr, self.rho, self.drho, 'b',
+                                               self.include_perturb_auf, self.mem_chunk_num,
+                                               **_kwargs)
 
     def group_sources(self, files_per_grouping, group_func=make_island_groupings):
         '''
@@ -1818,70 +1616,23 @@ class CrossMatch():
             potentially counterparts to one another.
         '''
 
-        # Each catalogue should expect 7 files in "group/" or "reject/": island
-        # lengths, indices into the opposite catalogue for each source, the
-        # indices of sources in this catalogue in each island, the number of
-        # opposing catalogue overlaps for each source, "field" and "bright" error
-        # circle lengths, and the list of any "rejected" source indices. However,
-        # there may be no "reject" arrays, so we might expect two fewer files.
-        if (np.all(['reject_a' not in f for f in
-                    os.listdir('{}/reject'.format(self.joint_folder_path))]) and
-            np.all(['reject_b' not in f for f in
-                    os.listdir('{}/reject'.format(self.joint_folder_path))])):
-            expected_files = (files_per_grouping - 1) * 2
-        else:
-            expected_files = files_per_grouping * 2
-        file_number = np.sum([len(files) for _, _, files in
-                              os.walk('{}/group'.format(self.joint_folder_path))]) + np.sum(
-            [len(files) for _, _, files in os.walk('{}/reject'.format(self.joint_folder_path))])
-        correct_file_number = expected_files == file_number
-
-        # First check whether we actually need to dip into the group sources
-        # routine or not.
-        if self.run_group or not correct_file_number:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Creating catalogue islands and overlaps...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            if self.j1s is None:
-                self.j1s = gsf.calc_j1s(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
-            # Only worry about the warning if we didn't choose to run the grouping
-            # but hit incorrect file numbers.
-            if not correct_file_number and not self.run_group:
-                warnings.warn('Rank {}, chunk {}: Incorrect number of grouping files. Deleting all '
-                              'grouping files and re-running cross-match process.'
-                              .format(self.rank, self.chunk_id))
-                self.run_cf, self.run_source = True, True
-            os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
-            os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
-            self.group_sources_data = \
-                group_func(self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                           self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_region_points,
-                           self.b_auf_region_points, self.a_filt_names, self.b_filt_names,
-                           self.a_cat_name, self.b_cat_name, self.a_modelrefinds, self.b_modelrefinds,
-                           self.r, self.dr, self.rho, self.drho,
-                           self.j1s, self.pos_corr_dist, self.cross_match_extent, self.int_fracs,
-                           self.mem_chunk_num, self.include_phot_like, self.use_phot_priors,
-                           self.n_pool, self.use_memmap_files)
-        else:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Loading catalogue islands and overlaps...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            if os.path.isfile('{}/reject/reject_a.npy'.format(self.joint_folder_path)):
-                lenrejecta = len(np.load('{}/reject/reject_a.npy'.format(self.joint_folder_path),
-                                         mmap_mode='r'))
-            else:
-                lenrejecta = 0
-            if os.path.isfile('{}/reject/reject_b.npy'.format(self.joint_folder_path)):
-                lenrejectb = len(np.load('{}/reject/reject_b.npy'.format(self.joint_folder_path),
-                                         mmap_mode='r'))
-            else:
-                lenrejectb = 0
-            self.group_sources_data = StageData(
-                ablen=None, bblen=None, ainds=None, binds=None, asize=None, bsize=None, aflen=None,
-                bflen=None, alist=None, blist=None, agrplen=None, bgrplen=None,
-                lenrejecta=lenrejecta, lenrejectb=lenrejectb)
+        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print('{} Rank {}, chunk {}: Creating catalogue islands and overlaps...'
+              .format(t, self.rank, self.chunk_id))
+        sys.stdout.flush()
+        if self.j1s is None:
+            self.j1s = gsf.calc_j1s(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
+        os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
+        os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
+        self.group_sources_data = \
+            group_func(self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
+                       self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_region_points,
+                       self.b_auf_region_points, self.a_filt_names, self.b_filt_names,
+                       self.a_cat_name, self.b_cat_name, self.a_modelrefinds, self.b_modelrefinds,
+                       self.r, self.dr, self.rho, self.drho,
+                       self.j1s, self.pos_corr_dist, self.cross_match_extent, self.int_fracs,
+                       self.mem_chunk_num, self.include_phot_like, self.use_phot_priors,
+                       self.n_pool)
 
     def calculate_phot_like(self, files_per_phot, phot_like_func=compute_photometric_likelihoods):
         '''
@@ -1898,48 +1649,23 @@ class CrossMatch():
             and "field" star photometric likelihood-related information.
         '''
 
-        # Saved files per catalogue: magnitude bins and bin array lengths, "field"
-        # source priors/likelihoods, and the sky slice index of each source.
-        # Additionally, "counterpart" prior/likelihood functions are saved, for
-        # 2 + 2 * 5 files total.
-        file_number = np.sum([len(files) for _, _, files in
-                              os.walk('{}/phot_like'.format(self.joint_folder_path))])
-        expected_file_number = 2 + 2 * files_per_phot
-
-        correct_file_number = expected_file_number == file_number
-
-        if self.run_cf or not correct_file_number:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Creating photometric priors and likelihoods...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            if not correct_file_number and not self.run_cf:
-                warnings.warn('Rank {}, chunk {}: Incorrect number of photometric likelihood '
-                              'files. Deleting all c/f files and re-running calculations.'
-                              .format(self.rank, self.chunk_id))
-                self.run_source = True
-            os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
-            self._calculate_cf_areas()
-            if self.use_phot_priors or self.include_phot_like:
-                bright_frac = self.int_fracs[0]
-                field_frac = self.int_fracs[1]
-            else:
-                bright_frac = None
-                field_frac = None
-            self.phot_like_data = phot_like_func(
-                    self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                    self.a_filt_names, self.b_filt_names, self.mem_chunk_num, self.cf_region_points,
-                    self.cf_areas, self.include_phot_like, self.use_phot_priors, self.group_sources_data,
-                    self.use_memmap_files, bright_frac, field_frac)
+        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print('{} Rank {}, chunk {}: Creating photometric priors and likelihoods...'
+              .format(t, self.rank, self.chunk_id))
+        sys.stdout.flush()
+        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
+        self._calculate_cf_areas()
+        if self.use_phot_priors or self.include_phot_like:
+            bright_frac = self.int_fracs[0]
+            field_frac = self.int_fracs[1]
         else:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Loading photometric priors and likelihoods...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            self.phot_like_data = StageData(
-                abinsarray=None, abinlengths=None, bbinsarray=None, bbinlengths=None,
-                a_sky_inds=None, b_sky_inds=None, c_priors=None, c_array=None, fa_priors=None,
-                fa_array=None, fb_priors=None, fb_array=None)
+            bright_frac = None
+            field_frac = None
+        self.phot_like_data = phot_like_func(
+            self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
+            self.a_filt_names, self.b_filt_names, self.mem_chunk_num, self.cf_region_points,
+            self.cf_areas, self.include_phot_like, self.use_phot_priors, self.group_sources_data,
+            bright_frac, field_frac)
 
     def _calculate_cf_areas(self):
         '''
@@ -1988,32 +1714,14 @@ class CrossMatch():
             The function that calls the counterpart determination routine.
         '''
 
-        file_number = np.sum([len(files) for _, _, files in
-                              os.walk('{}/pairing'.format(self.joint_folder_path))])
-        # No complicated maths here, since all files are common and in a single
-        # folder common to the pairing process.
-        expected_file_number = files_per_pairing
-
-        correct_file_number = expected_file_number == file_number
-
-        if self.run_source or not correct_file_number:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Determining counterparts...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
-            if not correct_file_number and not self.run_source:
-                warnings.warn('Rank {}, chunk {}: Incorrect number of counterpart pairing files. '
-                              'Deleting all files and re-running calculations.'
-                              .format(self.rank, self.chunk_id))
-            os.system('rm -r {}/pairing/*'.format(self.joint_folder_path))
-            count_pair_func(
-                self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names,
-                self.b_filt_names, self.a_auf_region_points, self.b_auf_region_points,
-                self.a_modelrefinds, self.b_modelrefinds, self.rho, self.drho, len(self.delta_mag_cuts),
-                self.mem_chunk_num, self.group_sources_data, self.phot_like_data, self.use_memmap_files)
-        else:
-            t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            print('{} Rank {}, chunk {}: Loading pre-assigned counterparts...'
-                  .format(t, self.rank, self.chunk_id))
-            sys.stdout.flush()
+        t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print('{} Rank {}, chunk {}: Determining counterparts...'
+              .format(t, self.rank, self.chunk_id))
+        sys.stdout.flush()
+        os.system('rm -r {}/pairing/*'.format(self.joint_folder_path))
+        count_pair_func(
+            self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
+            self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names,
+            self.b_filt_names, self.a_auf_region_points, self.b_auf_region_points,
+            self.a_modelrefinds, self.b_modelrefinds, self.rho, self.drho, len(self.delta_mag_cuts),
+            self.mem_chunk_num, self.group_sources_data, self.phot_like_data)

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -286,7 +286,7 @@ class CrossMatch():
             self.b_snr_mag_params = a
 
         # Ensure that we can create the folders for outputs.
-        for path in ['group', 'reject', 'phot_like', 'pairing']:
+        for path in ['reject', 'pairing']:
             try:
                 os.makedirs('{}/{}'.format(self.joint_folder_path, path), exist_ok=True)
             except OSError:
@@ -339,13 +339,6 @@ class CrossMatch():
                 if fn_m.shape[0] != fn_a.shape[0] or fn_p.shape[0] != fn_a.shape[0]:
                     raise ValueError("Consolidated catalogue arrays for catalogue {} should "
                                      "all be consistent lengths.".format(catname))
-
-        for folder in [self.a_cat_name, self.b_cat_name]:
-            try:
-                os.makedirs('{}/{}'.format(self.joint_folder_path, folder), exist_ok=True)
-            except OSError:
-                raise OSError("Error when trying to create temporary folder for catalogue-level "
-                              "outputs. Please ensure that catalogue folder names are correct.")
 
         self.make_shared_data()
 
@@ -1609,7 +1602,6 @@ class CrossMatch():
         sys.stdout.flush()
         if self.j1s is None:
             self.j1s = gsf.calc_j1s(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
-        os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         self.group_sources_data = \
             group_func(self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
@@ -1639,7 +1631,6 @@ class CrossMatch():
         print('{} Rank {}, chunk {}: Creating photometric priors and likelihoods...'
               .format(t, self.rank, self.chunk_id))
         sys.stdout.flush()
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         self._calculate_cf_areas()
         if self.use_phot_priors or self.include_phot_like:
             bright_frac = self.int_fracs[0]

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -1529,10 +1529,10 @@ class CrossMatch():
         else:
             os.system("rm -rf {}/*".format(self.a_auf_folder_path))
             _kwargs = {}
-        self.a_modelrefinds = perturb_auf_func(self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
-                                               self.a_auf_region_points, self.r, self.dr,
-                                               self.rho, self.drho, 'a', self.include_perturb_auf,
-                                               self.mem_chunk_num, **_kwargs)
+        self.a_modelrefinds, self.a_perturb_auf_outputs = perturb_auf_func(
+            self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
+            self.a_auf_region_points, self.r, self.dr, self.rho, self.drho, 'a',
+            self.include_perturb_auf, self.mem_chunk_num, **_kwargs)
 
         t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         print('{} Rank {}, chunk {}: Creating empirical perturbation AUFs for catalogue "b"...'
@@ -1582,11 +1582,10 @@ class CrossMatch():
         else:
             os.system("rm -rf {}/*".format(self.b_auf_folder_path))
             _kwargs = {}
-        self.b_modelrefinds = perturb_auf_func(self.b_auf_folder_path, self.b_cat_folder_path,
-                                               self.b_filt_names, self.b_auf_region_points, self.r,
-                                               self.dr, self.rho, self.drho, 'b',
-                                               self.include_perturb_auf, self.mem_chunk_num,
-                                               **_kwargs)
+        self.b_modelrefinds, self.b_perturb_auf_outputs = perturb_auf_func(
+            self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
+            self.b_auf_region_points, self.r, self.dr, self.rho, self.drho, 'b',
+            self.include_perturb_auf, self.mem_chunk_num, **_kwargs)
 
     def group_sources(self, files_per_grouping, group_func=make_island_groupings):
         '''
@@ -1614,13 +1613,12 @@ class CrossMatch():
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         self.group_sources_data = \
             group_func(self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                       self.a_auf_folder_path, self.b_auf_folder_path, self.a_auf_region_points,
-                       self.b_auf_region_points, self.a_filt_names, self.b_filt_names,
-                       self.a_cat_name, self.b_cat_name, self.a_modelrefinds, self.b_modelrefinds,
-                       self.r, self.dr, self.rho, self.drho,
+                       self.a_auf_region_points, self.b_auf_region_points, self.a_filt_names,
+                       self.b_filt_names, self.a_cat_name, self.b_cat_name, self.a_modelrefinds,
+                       self.b_modelrefinds, self.r, self.dr, self.rho, self.drho,
                        self.j1s, self.pos_corr_dist, self.cross_match_extent, self.int_fracs,
                        self.mem_chunk_num, self.include_phot_like, self.use_phot_priors,
-                       self.n_pool)
+                       self.n_pool, self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)
 
     def calculate_phot_like(self, files_per_phot, phot_like_func=compute_photometric_likelihoods):
         '''
@@ -1709,7 +1707,7 @@ class CrossMatch():
         os.system('rm -r {}/pairing/*'.format(self.joint_folder_path))
         count_pair_func(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-            self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names,
-            self.b_filt_names, self.a_auf_region_points, self.b_auf_region_points,
-            self.a_modelrefinds, self.b_modelrefinds, self.rho, self.drho, len(self.delta_mag_cuts),
-            self.mem_chunk_num, self.group_sources_data, self.phot_like_data)
+            self.a_filt_names, self.b_filt_names, self.a_auf_region_points,
+            self.b_auf_region_points, self.a_modelrefinds, self.b_modelrefinds, self.rho, self.drho,
+            len(self.delta_mag_cuts), self.mem_chunk_num, self.group_sources_data,
+            self.phot_like_data, self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -323,9 +323,9 @@ class CrossMatch():
                 # Shape, mapped to each of astro/photo/magref respectively,
                 # should map to 3, number of magnitudes, and 1, where magref is
                 # a 1-D array but the other two are 2-D.
-                fn_a = np.load('{}/con_cat_astro.npy'.format(path), mmap_mode='r')
-                fn_p = np.load('{}/con_cat_photo.npy'.format(path), mmap_mode='r')
-                fn_m = np.load('{}/magref.npy'.format(path), mmap_mode='r')
+                fn_a = np.load('{}/con_cat_astro.npy'.format(path))
+                fn_p = np.load('{}/con_cat_photo.npy'.format(path))
+                fn_m = np.load('{}/magref.npy'.format(path))
                 if len(fn_a.shape) != 2 or len(fn_p.shape) != 2 or len(fn_m.shape) != 1:
                     raise ValueError("Incorrect number of dimensions in consolidated "
                                      "catalogue {} files.".format(catname))
@@ -564,7 +564,7 @@ class CrossMatch():
                 [self.match_out_csv_name, self.a_nonmatch_out_csv_name,
                  self.b_nonmatch_out_csv_name], [self.a_cat_col_names, self.b_cat_col_names],
                 [self.a_cat_col_nums, self.b_cat_col_nums], [self.a_cat_name, self.b_cat_name],
-                self.mem_chunk_num, [self.a_input_npy_folder, self.b_input_npy_folder],
+                [self.a_input_npy_folder, self.b_input_npy_folder],
                 headers=[self.a_csv_has_header, self.b_csv_has_header],
                 extra_col_name_lists=[self.a_extra_col_names, self.b_extra_col_names],
                 extra_col_num_lists=[self.a_extra_col_nums, self.b_extra_col_nums])
@@ -774,7 +774,7 @@ class CrossMatch():
                            'cf_region_type', 'cf_region_frame', 'cf_region_points',
                            'joint_folder_path', 'pos_corr_dist', 'real_hankel_points',
                            'four_hankel_points', 'four_max_rho', 'cross_match_extent',
-                           'mem_chunk_num', 'int_fracs', 'make_output_csv', 'n_pool']:
+                           'int_fracs', 'make_output_csv', 'n_pool']:
             if check_flag not in joint_config:
                 raise ValueError("Missing key {} from joint metadata file.".format(check_flag))
 
@@ -1092,15 +1092,6 @@ class CrossMatch():
         if len(b) != 4:
             raise ValueError("cross_match_extent should contain four elements.")
         self.cross_match_extent = b
-
-        try:
-            a = joint_config['mem_chunk_num']
-            if float(a).is_integer():
-                self.mem_chunk_num = int(a)
-            else:
-                raise ValueError("mem_chunk_num should be a single integer number.")
-        except ValueError:
-            raise ValueError("mem_chunk_num should be a single integer number.")
 
         a = joint_config['int_fracs'].split()
         try:
@@ -1510,7 +1501,7 @@ class CrossMatch():
         self.a_modelrefinds, self.a_perturb_auf_outputs = perturb_auf_func(
             self.a_auf_folder_path, self.a_cat_folder_path, self.a_filt_names,
             self.a_auf_region_points, self.r, self.dr, self.rho, self.drho, 'a',
-            self.include_perturb_auf, self.mem_chunk_num, **_kwargs)
+            self.include_perturb_auf, **_kwargs)
 
         t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         print('{} Rank {}, chunk {}: Creating empirical perturbation AUFs for catalogue "b"...'
@@ -1551,7 +1542,7 @@ class CrossMatch():
         self.b_modelrefinds, self.b_perturb_auf_outputs = perturb_auf_func(
             self.b_auf_folder_path, self.b_cat_folder_path, self.b_filt_names,
             self.b_auf_region_points, self.r, self.dr, self.rho, self.drho, 'b',
-            self.include_perturb_auf, self.mem_chunk_num, **_kwargs)
+            self.include_perturb_auf, **_kwargs)
 
     def group_sources(self, group_func=make_island_groupings):
         '''
@@ -1579,7 +1570,7 @@ class CrossMatch():
                        self.b_filt_names, self.a_cat_name, self.b_cat_name, self.a_modelrefinds,
                        self.b_modelrefinds, self.r, self.dr, self.rho, self.drho,
                        self.j1s, self.pos_corr_dist, self.cross_match_extent, self.int_fracs,
-                       self.mem_chunk_num, self.include_phot_like, self.use_phot_priors,
+                       self.include_phot_like, self.use_phot_priors,
                        self.n_pool, self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)
 
     def calculate_phot_like(self, phot_like_func=compute_photometric_likelihoods):
@@ -1607,9 +1598,9 @@ class CrossMatch():
             field_frac = None
         self.phot_like_data = phot_like_func(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-            self.a_filt_names, self.b_filt_names, self.mem_chunk_num, self.cf_region_points,
-            self.cf_areas, self.include_phot_like, self.use_phot_priors, self.group_sources_data,
-            bright_frac, field_frac)
+            self.a_filt_names, self.b_filt_names, self.cf_region_points, self.cf_areas,
+            self.include_phot_like, self.use_phot_priors, self.group_sources_data, bright_frac,
+            field_frac)
 
     def _calculate_cf_areas(self):
         '''
@@ -1665,5 +1656,5 @@ class CrossMatch():
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
             self.a_filt_names, self.b_filt_names, self.a_auf_region_points,
             self.b_auf_region_points, self.a_modelrefinds, self.b_modelrefinds, self.rho, self.drho,
-            len(self.delta_mag_cuts), self.mem_chunk_num, self.group_sources_data,
+            len(self.delta_mag_cuts), self.group_sources_data,
             self.phot_like_data, self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)

--- a/macauff/matching.py
+++ b/macauff/matching.py
@@ -5,7 +5,6 @@ This module provides the high-level framework for performing catalogue-catalogue
 
 import os
 import sys
-import warnings
 import datetime
 from configparser import ConfigParser
 from time import sleep
@@ -19,7 +18,6 @@ except:
 from .perturbation_auf import make_perturb_aufs
 from .group_sources import make_island_groupings
 from .group_sources_fortran import group_sources_fortran as gsf
-from .misc_functions import StageData
 from .misc_functions_fortran import misc_functions_fortran as mff
 from .photometric_likelihood import compute_photometric_likelihoods
 from .counterpart_pairing import source_pairing

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -144,7 +144,7 @@ def hav_dist_constant_lat(x_lon, x_lat, lon):
     return dist
 
 
-def map_large_index_to_small_index(inds, length, folder):
+def map_large_index_to_small_index(inds, length):
     inds_unique_flat = np.unique(inds[inds > -1])
     map_array = np.zeros(dtype=int, shape=(length,))
     map_array[:] = -1

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -18,7 +18,7 @@ class StageData:
 
 
 def create_auf_params_grid(auf_folder_path, auf_pointings, filt_names, array_name,
-                           use_memmap_files, len_first_axis=None, arraylengths=None):
+                           arraylengths, len_first_axis=None):
     '''
     Minor function to offload the creation of a 3-D or 4-D array from a series
     of 2-D arrays.
@@ -35,20 +35,13 @@ def create_auf_params_grid(auf_folder_path, auf_pointings, filt_names, array_nam
     array_name : string
         The name of the individually-saved arrays, one per sub-folder, to turn
         into a 3-D or 4-D array.
-    use_memmap_files : boolean
-        When set to True, memory mapped files are used for several internal
-        arrays. Reduces memory consumption at the cost of increased I/O
-        contention.
+    arraylengths : numpy.ndarray
+        Array containing length of the density-magnitude combinations in each
+        sky/filter combination.
     len_first_axis : integer, optional
         Length of the initial axis of the 4-D array. If not provided or is
         ``None``, final array is assumed to be 3-D instead.
-    arraylengths : numpy.ndarray, optional
-        Array containing length of the density-magnitude combinations in each
-        sky/filter combination. Used only when use_memmap_files is True.
-        Otherwise, is reloaded from disk.
     '''
-    if use_memmap_files:
-        arraylengths = np.load('{}/arraylengths.npy'.format(auf_folder_path))
     longestNm = np.amax(arraylengths)
     if len_first_axis is None:
         grid = np.lib.format.open_memmap('{}/{}_grid.npy'.format(
@@ -70,8 +63,7 @@ def create_auf_params_grid(auf_folder_path, auf_pointings, filt_names, array_nam
                 grid[:arraylengths[i, j], i, j] = single_array
             else:
                 grid[:, :arraylengths[i, j], i, j] = single_array
-    if use_memmap_files:
-        del arraylengths
+
     del longestNm, grid
 
 
@@ -153,25 +145,18 @@ def hav_dist_constant_lat(x_lon, x_lat, lon):
     return dist
 
 
-def map_large_index_to_small_index(inds, length, folder, use_memmap_files):
+def map_large_index_to_small_index(inds, length, folder):
     inds_unique_flat = np.unique(inds[inds > -1])
-    if use_memmap_files:
-        map_array = np.lib.format.open_memmap('{}/map_array.npy'.format(folder), mode='w+', dtype=int,
-                                            shape=(length,))
-    else:
-        map_array = np.zeros(dtype=int, shape=(length,))
+    map_array = np.zeros(dtype=int, shape=(length,))
     map_array[:] = -1
     map_array[inds_unique_flat] = np.arange(0, len(inds_unique_flat), dtype=int)
     inds_map = np.asfortranarray(map_array[inds.flatten()].reshape(inds.shape))
-    if use_memmap_files:
-        os.system('rm {}/map_array.npy'.format(folder))
-    else:
-        del map_array
+    del map_array
 
     return inds_map, inds_unique_flat
 
 
-def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds, use_memmap_files):
+def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds):
     '''
     Function to, in a memmap-friendly way, return a sub-set of the nearest sky
     indices of a given catalogue.
@@ -190,10 +175,6 @@ def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds, use_memmap_file
     sky_inds : numpy.ndarray
         The given catalogue's ``distribute_sky_indices`` values, to compare
         with ``ind``.
-    use_memmap_files : boolean
-        When set to True, memory mapped files are used for several internal
-        arrays. Reduces memory consumption at the cost of increased I/O
-        contention.
 
     Returns
     -------
@@ -201,11 +182,7 @@ def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds, use_memmap_file
         A boolean array, indicating whether each element in ``sky_inds`` matches
         ``ind`` or not.
     '''
-    if use_memmap_files:
-        sky_cut = np.lib.format.open_memmap('{}/{}_small_sky_slice.npy'.format(
-            folder_path, cat_name), mode='w+', dtype=bool, shape=(len(sky_inds),))
-    else:
-        sky_cut = np.zeros(dtype=bool, shape=(len(sky_inds),))
+    sky_cut = np.zeros(dtype=bool, shape=(len(sky_inds),))
 
     di = max(1, len(sky_inds) // 20)
 

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -144,17 +144,6 @@ def hav_dist_constant_lat(x_lon, x_lat, lon):
     return dist
 
 
-def map_large_index_to_small_index(inds, length):
-    inds_unique_flat = np.unique(inds[inds > -1])
-    map_array = np.zeros(dtype=int, shape=(length,))
-    map_array[:] = -1
-    map_array[inds_unique_flat] = np.arange(0, len(inds_unique_flat), dtype=int)
-    inds_map = np.asfortranarray(map_array[inds.flatten()].reshape(inds.shape))
-    del map_array
-
-    return inds_map, inds_unique_flat
-
-
 def _load_rectangular_slice(cat_name, a, lon1, lon2, lat1, lat2, padding):
     '''
     Loads all sources in a catalogue within a given separation of a rectangle

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -191,37 +191,7 @@ def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds):
     return sky_cut
 
 
-def _create_rectangular_slice_arrays(folder_path, cat_name, len_a):
-    '''
-    Create temporary sky slice memmap arrays for parts of the cross-match
-    process to use.
-
-    Parameters
-    ----------
-    folder_path : string
-        Location of where to store memmap arrays.
-    cat_name : string
-        Unique indicator of which catalogue these arrays are for.
-    len_a : integer
-        The length of the catalogue in question, allowing for a one-to-one
-        mapping of sky slice per source.
-    '''
-    np.lib.format.open_memmap('{}/{}_temporary_sky_slice_1.npy'.format(
-        folder_path, cat_name), mode='w+', dtype=bool, shape=(len_a,))
-    np.lib.format.open_memmap('{}/{}_temporary_sky_slice_2.npy'.format(
-        folder_path, cat_name), mode='w+', dtype=bool, shape=(len_a,))
-    np.lib.format.open_memmap('{}/{}_temporary_sky_slice_3.npy'.format(
-        folder_path, cat_name), mode='w+', dtype=bool, shape=(len_a,))
-    np.lib.format.open_memmap('{}/{}_temporary_sky_slice_4.npy'.format(
-        folder_path, cat_name), mode='w+', dtype=bool, shape=(len_a,))
-    np.lib.format.open_memmap('{}/{}_temporary_sky_slice_combined.npy'.format(
-        folder_path, cat_name), mode='w+', dtype=bool, shape=(len_a,))
-
-    return
-
-
-def _load_rectangular_slice(folder_path, cat_name, a, lon1, lon2, lat1, lat2, padding,
-                            memmap_arrays):
+def _load_rectangular_slice(folder_path, cat_name, a, lon1, lon2, lat1, lat2, padding):
     '''
     Loads all sources in a catalogue within a given separation of a rectangle
     in sky coordinates, allowing for the search for all sources within a given
@@ -249,9 +219,6 @@ def _load_rectangular_slice(folder_path, cat_name, a, lon1, lon2, lat1, lat2, pa
     padding : float
         The sky separation, in degrees, to find all sources within a distance
         of in ``a``.
-    memmap_arrays : list of numpy.ndarray
-        The list of temporary arrays to use for memory-friendly sky coordinate
-        slicing.
 
     Returns
     -------
@@ -260,9 +227,11 @@ def _load_rectangular_slice(folder_path, cat_name, a, lon1, lon2, lat1, lat2, pa
         of the rectangle defined by ``lon1``, ``lon2``, ``lat1``, and ``lat2``.
     '''
 
-    # Slice the memmapped catalogue, with a memmapped slicing array to
-    # preserve memory.
-    sky_cut_1, sky_cut_2, sky_cut_3, sky_cut_4, sky_cut = memmap_arrays
+    sky_cut_1 = np.empty(len(a), bool)
+    sky_cut_2 = np.empty(len(a), bool)
+    sky_cut_3 = np.empty(len(a), bool)
+    sky_cut_4 = np.empty(len(a), bool)
+    sky_cut = np.empty(len(a), bool)
 
     di = max(1, len(a) // 20)
     # Iterate over each small slice of the larger array, checking for upper

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -4,7 +4,6 @@ This module provides miscellaneous scripts, called in other parts of the cross-m
 framework.
 '''
 
-import os
 import numpy as np
 
 __all__ = []

--- a/macauff/misc_functions.py
+++ b/macauff/misc_functions.py
@@ -155,15 +155,12 @@ def map_large_index_to_small_index(inds, length):
     return inds_map, inds_unique_flat
 
 
-def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds):
+def _load_single_sky_slice(cat_name, ind, sky_inds):
     '''
-    Function to, in a memmap-friendly way, return a sub-set of the nearest sky
-    indices of a given catalogue.
+    Function to return a sub-set of the nearest sky indices of a given catalogue.
 
     Parameters
     ----------
-    folder_path : string
-        Folder in which to store the temporary memmap file.
     cat_name : string
         String defining whether this function was called on catalogue "a" or "b".
     ind : float
@@ -191,7 +188,7 @@ def _load_single_sky_slice(folder_path, cat_name, ind, sky_inds):
     return sky_cut
 
 
-def _load_rectangular_slice(folder_path, cat_name, a, lon1, lon2, lat1, lat2, padding):
+def _load_rectangular_slice(cat_name, a, lon1, lon2, lat1, lat2, padding):
     '''
     Loads all sources in a catalogue within a given separation of a rectangle
     in sky coordinates, allowing for the search for all sources within a given
@@ -199,9 +196,6 @@ def _load_rectangular_slice(folder_path, cat_name, a, lon1, lon2, lat1, lat2, pa
 
     Parameters
     ----------
-    folder_path : string
-        Location of where the memmap files used in the slicing of the
-        catalogue are stored.
     cat_name : string
         Indication of whether we are loading catalogue "a" or catalogue "b",
         for separation within a given folder.
@@ -264,7 +258,7 @@ def _lon_cut(i, a, di, lon, padding, sky_cut, inequality, lon_shift):
     i : integer
         Index into ``sky_cut`` for slicing.
     a : numpy.ndarray
-        The main astrometric catalogue to be sliced, loaded into memmap.
+        The main astrometric catalogue to be sliced.
     di : integer
         Index stride value, for slicing.
     lon : float
@@ -319,7 +313,7 @@ def _lat_cut(i, a, di, lat, padding, sky_cut, inequality):
     i : integer
         Index into ``sky_cut`` for slicing.
     a : numpy.ndarray
-        The main astrometric catalogue to be sliced, loaded into memmap.
+        The main astrometric catalogue to be sliced.
     di : integer
         Index stride value, for slicing.
     lat : float

--- a/macauff/parse_catalogue.py
+++ b/macauff/parse_catalogue.py
@@ -462,7 +462,7 @@ def rect_slice_csv(input_folder, output_folder, input_filename, output_filename,
         small_astro[n:n+chunk.shape[0]] = chunk.values
         n += chunk.shape[0]
 
-    sky_cut = _load_rectangular_slice(input_folder, '', small_astro, rect_coords[0], rect_coords[1],
+    sky_cut = _load_rectangular_slice('', small_astro, rect_coords[0], rect_coords[1],
                                       rect_coords[2], rect_coords[3], padding)
 
     n_inside_rows = 0
@@ -526,8 +526,8 @@ def rect_slice_npy(input_folder, output_folder, rect_coords, padding, mem_chunk_
     photo = np.load('{}/con_cat_photo.npy'.format(input_folder), mmap_mode='r')
     best_index = np.load('{}/magref.npy'.format(input_folder), mmap_mode='r')
     n_rows = len(astro)
-    sky_cut = _load_rectangular_slice(input_folder, '', astro, rect_coords[0], rect_coords[1],
-                                      rect_coords[2], rect_coords[3], padding)
+    sky_cut = _load_rectangular_slice('', astro, rect_coords[0], rect_coords[1], rect_coords[2],
+                                      rect_coords[3], padding)
 
     n_inside_rows = 0
     for cnum in range(0, mem_chunk_num):

--- a/macauff/parse_catalogue.py
+++ b/macauff/parse_catalogue.py
@@ -161,8 +161,8 @@ def csv_to_npy(input_folder, input_filename, output_folder, astro_cols, photo_co
 
 def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenames,
                output_filenames, column_name_lists, column_num_lists, extra_col_cat_names,
-               mem_chunk_num, input_npy_folders, headers=[False, False],
-               extra_col_name_lists=[None, None], extra_col_num_lists=[None, None]):
+               input_npy_folders, headers=[False, False], extra_col_name_lists=[None, None],
+               extra_col_num_lists=[None, None]):
     '''
     Function to convert output .npy files, as created during the cross-match
     process, and create a .csv file of matches and non-matches, combining columns
@@ -196,9 +196,6 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         List of two strings, one per catalogue, indicating the names of the two
         catalogues, to append to the front of the derived contamination-based
         values included in the output datasets.
-    mem_chunk_num : integer
-        Indicator of how many subsets of the catalogue to load each catalogue in,
-        for memory related issues.
     input_npy_folders : list of strings
         List of folders in which the respective catalogues' .npy files were
         saved to, as part of ``csv_to_npy``, in the same order as
@@ -247,23 +244,23 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
                               "catalogue.".format(entry))
         if extra_col_num_lists[i] is not None:
             cols = np.append(cols, extra_col_name_lists[i])
-    ac = np.load('{}/pairing/ac.npy'.format(input_match_folder), mmap_mode='r')
-    bc = np.load('{}/pairing/bc.npy'.format(input_match_folder), mmap_mode='r')
-    p = np.load('{}/pairing/pc.npy'.format(input_match_folder), mmap_mode='r')
-    eta = np.load('{}/pairing/eta.npy'.format(input_match_folder), mmap_mode='r')
-    xi = np.load('{}/pairing/xi.npy'.format(input_match_folder), mmap_mode='r')
-    a_avg_cont = np.load('{}/pairing/acontamflux.npy'.format(input_match_folder), mmap_mode='r')
-    b_avg_cont = np.load('{}/pairing/bcontamflux.npy'.format(input_match_folder), mmap_mode='r')
-    acontprob = np.load('{}/pairing/pacontam.npy'.format(input_match_folder), mmap_mode='r')
-    bcontprob = np.load('{}/pairing/pbcontam.npy'.format(input_match_folder), mmap_mode='r')
-    seps = np.load('{}/pairing/crptseps.npy'.format(input_match_folder), mmap_mode='r')
+    ac = np.load('{}/pairing/ac.npy'.format(input_match_folder))
+    bc = np.load('{}/pairing/bc.npy'.format(input_match_folder))
+    p = np.load('{}/pairing/pc.npy'.format(input_match_folder))
+    eta = np.load('{}/pairing/eta.npy'.format(input_match_folder))
+    xi = np.load('{}/pairing/xi.npy'.format(input_match_folder))
+    a_avg_cont = np.load('{}/pairing/acontamflux.npy'.format(input_match_folder))
+    b_avg_cont = np.load('{}/pairing/bcontamflux.npy'.format(input_match_folder))
+    acontprob = np.load('{}/pairing/pacontam.npy'.format(input_match_folder))
+    bcontprob = np.load('{}/pairing/pbcontam.npy'.format(input_match_folder))
+    seps = np.load('{}/pairing/crptseps.npy'.format(input_match_folder))
 
     if input_npy_folders[0] is not None:
         cols = np.append(cols, ['{}_FIT_SIG'.format(extra_col_cat_names[0])])
-        a_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[0]), mmap_mode='r')
+        a_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[0]))
     if input_npy_folders[1] is not None:
         cols = np.append(cols, ['{}_FIT_SIG'.format(extra_col_cat_names[1])])
-        b_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[1]), mmap_mode='r')
+        b_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[1]))
 
     n_amags, n_bmags = len(column_name_lists[0]) - 3, len(column_name_lists[1]) - 3
     if extra_col_num_lists[0] is None:
@@ -289,57 +286,53 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     n_matches = len(ac)
     match_df = pd.DataFrame(columns=cols, index=np.arange(0, n_matches))
 
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(n_matches*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(n_matches*(cnum+1)/mem_chunk_num).astype(int)
-        for i in column_name_lists[0]:
-            match_df[i].iloc[lowind:highind] = cat_a[i].iloc[ac[lowind:highind]].values
-        for i in column_name_lists[1]:
-            match_df[i].iloc[lowind:highind] = cat_b[i].iloc[bc[lowind:highind]].values
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags] = p[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+1] = seps[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+2] = eta[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+3] = xi[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+4] = a_avg_cont[lowind:highind]
-        match_df.iloc[lowind:highind, 6+n_amags+n_bmags+5] = b_avg_cont[lowind:highind]
-        for i in range(acontprob.shape[0]):
-            match_df.iloc[lowind:highind, 6+n_amags+n_bmags+6+i] = acontprob[i, lowind:highind]
-        for i in range(bcontprob.shape[0]):
-            match_df.iloc[lowind:highind, 6+n_amags+n_bmags+6+acontprob.shape[0]+i] = bcontprob[
-                i, lowind:highind]
-        if extra_col_name_lists[0] is not None:
-            for i in extra_col_name_lists[0]:
-                match_df[i].iloc[lowind:highind] = cat_a[i].iloc[ac[lowind:highind]].values
-        if extra_col_name_lists[1] is not None:
-            for i in extra_col_name_lists[1]:
-                match_df[i].iloc[lowind:highind] = cat_b[i].iloc[bc[lowind:highind]].values
+    for i in column_name_lists[0]:
+        match_df[i].iloc[:] = cat_a[i].iloc[ac].values
+    for i in column_name_lists[1]:
+        match_df[i].iloc[:] = cat_b[i].iloc[bc].values
+    match_df.iloc[:, 6+n_amags+n_bmags] = p
+    match_df.iloc[:, 6+n_amags+n_bmags+1] = seps
+    match_df.iloc[:, 6+n_amags+n_bmags+2] = eta
+    match_df.iloc[:, 6+n_amags+n_bmags+3] = xi
+    match_df.iloc[:, 6+n_amags+n_bmags+4] = a_avg_cont
+    match_df.iloc[:, 6+n_amags+n_bmags+5] = b_avg_cont
+    for i in range(acontprob.shape[0]):
+        match_df.iloc[:, 6+n_amags+n_bmags+6+i] = acontprob[i, :]
+    for i in range(bcontprob.shape[0]):
+        match_df.iloc[:, 6+n_amags+n_bmags+6+acontprob.shape[0]+i] = bcontprob[i, :]
+    if extra_col_name_lists[0] is not None:
+        for i in extra_col_name_lists[0]:
+            match_df[i].iloc[:] = cat_a[i].iloc[ac].values
+    if extra_col_name_lists[1] is not None:
+        for i in extra_col_name_lists[1]:
+            match_df[i].iloc[:] = cat_b[i].iloc[bc].values
 
-        # FIT_SIG are the last 0-2 columns, after [ID+coords(x2)+mag(xN)]x2 +
-        # Q match-made columns, plus len(extra_col_name_lists)x2.
-        if input_npy_folders[0] is not None:
-            ind = (len(column_name_lists[0]) + len(column_name_lists[1]) + len(our_columns) +
-                   (len(extra_col_name_lists[0]) if extra_col_name_lists[0] is not None else 0) +
-                   (len(extra_col_name_lists[1]) if extra_col_name_lists[1] is not None else 0))
-            match_df.iloc[lowind:highind, ind] = a_concatastro[ac[lowind:highind], 2]
-        if input_npy_folders[1] is not None:
-            # Here we also need to check if catalogue "a" has processed uncertainties too.
-            _dx = 1 if input_npy_folders[0] is not None else 0
-            ind = (len(column_name_lists[0]) + len(column_name_lists[1]) + len(our_columns) +
-                   (len(extra_col_name_lists[0]) if extra_col_name_lists[0] is not None else 0) +
-                   (len(extra_col_name_lists[1]) if extra_col_name_lists[1] is not None else 0)) + _dx
-            match_df.iloc[lowind:highind, ind] = b_concatastro[bc[lowind:highind], 2]
+    # FIT_SIG are the last 0-2 columns, after [ID+coords(x2)+mag(xN)]x2 +
+    # Q match-made columns, plus len(extra_col_name_lists)x2.
+    if input_npy_folders[0] is not None:
+        ind = (len(column_name_lists[0]) + len(column_name_lists[1]) + len(our_columns) +
+               (len(extra_col_name_lists[0]) if extra_col_name_lists[0] is not None else 0) +
+               (len(extra_col_name_lists[1]) if extra_col_name_lists[1] is not None else 0))
+        match_df.iloc[:, ind] = a_concatastro[ac, 2]
+    if input_npy_folders[1] is not None:
+        # Here we also need to check if catalogue "a" has processed uncertainties too.
+        _dx = 1 if input_npy_folders[0] is not None else 0
+        ind = (len(column_name_lists[0]) + len(column_name_lists[1]) + len(our_columns) +
+               (len(extra_col_name_lists[0]) if extra_col_name_lists[0] is not None else 0) +
+               (len(extra_col_name_lists[1]) if extra_col_name_lists[1] is not None else 0)) + _dx
+        match_df.iloc[:, ind] = b_concatastro[bc, 2]
 
     match_df.to_csv('{}/{}'.format(output_folder, output_filenames[0]), encoding='utf-8',
                     index=False, header=False)
 
     # For non-match, ID/coordinates/mags, then island probability + average
     # contamination.
-    af = np.load('{}/pairing/af.npy'.format(input_match_folder), mmap_mode='r')
-    a_avg_cont = np.load('{}/pairing/afieldflux.npy'.format(input_match_folder), mmap_mode='r')
-    p = np.load('{}/pairing/pfa.npy'.format(input_match_folder), mmap_mode='r')
-    seps = np.load('{}/pairing/afieldseps.npy'.format(input_match_folder), mmap_mode='r')
-    afeta = np.load('{}/pairing/afieldeta.npy'.format(input_match_folder), mmap_mode='r')
-    afxi = np.load('{}/pairing/afieldxi.npy'.format(input_match_folder), mmap_mode='r')
+    af = np.load('{}/pairing/af.npy'.format(input_match_folder))
+    a_avg_cont = np.load('{}/pairing/afieldflux.npy'.format(input_match_folder))
+    p = np.load('{}/pairing/pfa.npy'.format(input_match_folder))
+    seps = np.load('{}/pairing/afieldseps.npy'.format(input_match_folder))
+    afeta = np.load('{}/pairing/afieldeta.npy'.format(input_match_folder))
+    afxi = np.load('{}/pairing/afieldxi.npy'.format(input_match_folder))
     our_columns = ['MATCH_P', 'NNM_SEPARATION', 'NNM_ETA', 'NNM_XI',
                    '{}_AVG_CONT'.format(extra_col_cat_names[0])]
     cols = np.append(column_name_lists[0], our_columns)
@@ -347,37 +340,34 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         cols = np.append(cols, extra_col_name_lists[0])
     if input_npy_folders[0] is not None:
         cols = np.append(cols, ['{}_FIT_SIG'.format(extra_col_cat_names[0])])
-        a_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[0]), mmap_mode='r')
+        a_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[0]))
     n_anonmatches = len(af)
     a_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_anonmatches))
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(n_anonmatches*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(n_anonmatches*(cnum+1)/mem_chunk_num).astype(int)
-        for i in column_name_lists[0]:
-            a_nonmatch_df[i].iloc[lowind:highind] = cat_a[i].iloc[af[lowind:highind]].values
-        a_nonmatch_df.iloc[lowind:highind, 3+n_amags] = p[lowind:highind]
-        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+1] = seps[lowind:highind]
-        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+2] = afeta[lowind:highind]
-        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+3] = afxi[lowind:highind]
-        a_nonmatch_df.iloc[lowind:highind, 3+n_amags+4] = a_avg_cont[lowind:highind]
-        if extra_col_name_lists[0] is not None:
-            for i in extra_col_name_lists[0]:
-                a_nonmatch_df[i].iloc[lowind:highind] = cat_a[i].iloc[af[lowind:highind]].values
+    for i in column_name_lists[0]:
+        a_nonmatch_df[i].iloc[:] = cat_a[i].iloc[af].values
+    a_nonmatch_df.iloc[:, 3+n_amags] = p
+    a_nonmatch_df.iloc[:, 3+n_amags+1] = seps
+    a_nonmatch_df.iloc[:, 3+n_amags+2] = afeta
+    a_nonmatch_df.iloc[:, 3+n_amags+3] = afxi
+    a_nonmatch_df.iloc[:, 3+n_amags+4] = a_avg_cont
+    if extra_col_name_lists[0] is not None:
+        for i in extra_col_name_lists[0]:
+            a_nonmatch_df[i].iloc[:] = cat_a[i].iloc[af].values
 
-        if input_npy_folders[0] is not None:
-            ind = (len(column_name_lists[0]) + len(our_columns) +
-                   (len(extra_col_name_lists[0]) if extra_col_name_lists[0] is not None else 0))
-            a_nonmatch_df.iloc[lowind:highind, ind] = a_concatastro[af[lowind:highind], 2]
+    if input_npy_folders[0] is not None:
+        ind = (len(column_name_lists[0]) + len(our_columns) +
+               (len(extra_col_name_lists[0]) if extra_col_name_lists[0] is not None else 0))
+        a_nonmatch_df.iloc[:, ind] = a_concatastro[af, 2]
 
     a_nonmatch_df.to_csv('{}/{}'.format(output_folder, output_filenames[1]), encoding='utf-8',
                          index=False, header=False)
 
-    bf = np.load('{}/pairing/bf.npy'.format(input_match_folder), mmap_mode='r')
-    b_avg_cont = np.load('{}/pairing/bfieldflux.npy'.format(input_match_folder), mmap_mode='r')
-    p = np.load('{}/pairing/pfb.npy'.format(input_match_folder), mmap_mode='r')
-    seps = np.load('{}/pairing/bfieldseps.npy'.format(input_match_folder), mmap_mode='r')
-    bfeta = np.load('{}/pairing/bfieldeta.npy'.format(input_match_folder), mmap_mode='r')
-    bfxi = np.load('{}/pairing/bfieldxi.npy'.format(input_match_folder), mmap_mode='r')
+    bf = np.load('{}/pairing/bf.npy'.format(input_match_folder))
+    b_avg_cont = np.load('{}/pairing/bfieldflux.npy'.format(input_match_folder))
+    p = np.load('{}/pairing/pfb.npy'.format(input_match_folder))
+    seps = np.load('{}/pairing/bfieldseps.npy'.format(input_match_folder))
+    bfeta = np.load('{}/pairing/bfieldeta.npy'.format(input_match_folder))
+    bfxi = np.load('{}/pairing/bfieldxi.npy'.format(input_match_folder))
     our_columns = ['MATCH_P', 'NNM_SEPARATION', 'NNM_ETA', 'NNM_XI',
                    '{}_AVG_CONT'.format(extra_col_cat_names[1])]
     cols = np.append(column_name_lists[1], our_columns)
@@ -385,27 +375,24 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         cols = np.append(cols, extra_col_name_lists[1])
     if input_npy_folders[1] is not None:
         cols = np.append(cols, ['{}_FIT_SIG'.format(extra_col_cat_names[1])])
-        b_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[1]), mmap_mode='r')
+        b_concatastro = np.load('{}/con_cat_astro.npy'.format(input_npy_folders[1]))
     n_bnonmatches = len(bf)
     b_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_bnonmatches))
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(n_bnonmatches*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(n_bnonmatches*(cnum+1)/mem_chunk_num).astype(int)
-        for i in column_name_lists[1]:
-            b_nonmatch_df[i].iloc[lowind:highind] = cat_b[i].iloc[bf[lowind:highind]].values
-        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags] = p[lowind:highind]
-        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+1] = seps[lowind:highind]
-        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+2] = bfeta[lowind:highind]
-        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+3] = bfxi[lowind:highind]
-        b_nonmatch_df.iloc[lowind:highind, 3+n_bmags+4] = b_avg_cont[lowind:highind]
-        if extra_col_name_lists[1] is not None:
-            for i in extra_col_name_lists[1]:
-                b_nonmatch_df[i].iloc[lowind:highind] = cat_b[i].iloc[bf[lowind:highind]].values
+    for i in column_name_lists[1]:
+        b_nonmatch_df[i].iloc[:] = cat_b[i].iloc[bf].values
+    b_nonmatch_df.iloc[:, 3+n_bmags] = p
+    b_nonmatch_df.iloc[:, 3+n_bmags+1] = seps
+    b_nonmatch_df.iloc[:, 3+n_bmags+2] = bfeta
+    b_nonmatch_df.iloc[:, 3+n_bmags+3] = bfxi
+    b_nonmatch_df.iloc[:, 3+n_bmags+4] = b_avg_cont
+    if extra_col_name_lists[1] is not None:
+        for i in extra_col_name_lists[1]:
+            b_nonmatch_df[i].iloc[:] = cat_b[i].iloc[bf].values
 
-        if input_npy_folders[1] is not None:
-            ind = (len(column_name_lists[1]) + len(our_columns) +
-                   (len(extra_col_name_lists[1]) if extra_col_name_lists[1] is not None else 0))
-            b_nonmatch_df.iloc[lowind:highind, ind] = b_concatastro[bf[lowind:highind], 2]
+    if input_npy_folders[1] is not None:
+        ind = (len(column_name_lists[1]) + len(our_columns) +
+               (len(extra_col_name_lists[1]) if extra_col_name_lists[1] is not None else 0))
+        b_nonmatch_df.iloc[:, ind] = b_concatastro[bf, 2]
 
     b_nonmatch_df.to_csv('{}/{}'.format(output_folder, output_filenames[2]), encoding='utf-8',
                          index=False, header=False)

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -301,10 +301,7 @@ def make_perturb_aufs(auf_folder, cat_folder, filters, auf_points, r, dr, rho,
             os.makedirs(ax_folder, exist_ok=True)
 
         if include_perturb_auf:
-            sky_cut = _load_single_sky_slice(auf_folder, '', i, modelrefinds[2, :])
-            # TODO: avoid np.arange by first iterating an np.sum(sky_cut)
-            # and pre-generating a memmapped sub-array, and looping over
-            # putting the correct indices into place.
+            sky_cut = _load_single_sky_slice('', i, modelrefinds[2, :])
             med_index_slice = np.arange(0, len(local_N))[sky_cut]
             a_photo_cut = a_tot_photo[sky_cut]
             a_astro_cut = a_tot_astro[sky_cut]
@@ -702,8 +699,8 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
     min_lon, max_lon = min_max_lon(a_astro[:, 0])
     min_lat, max_lat = np.amin(a_astro[:, 1]), np.amax(a_astro[:, 1])
 
-    overlap_sky_cut = _load_rectangular_slice(auf_folder, '', a_tot_astro, min_lon,
-                                              max_lon, min_lat, max_lat, density_radius)
+    overlap_sky_cut = _load_rectangular_slice('', a_tot_astro, min_lon, max_lon, min_lat, max_lat,
+                                              density_radius)
     cut = np.zeros(dtype=bool, shape=(len(a_tot_astro),))
     di = max(1, len(cut) // 20)
     for i in range(0, len(a_tot_astro), di):
@@ -724,15 +721,14 @@ def calculate_local_density(a_astro, a_tot_astro, a_tot_photo, auf_folder, cat_f
     full_counts = np.empty(len(a_astro), float)
     for ax1_start, ax1_end in zip(ax1_loops[:-1], ax1_loops[1:]):
         for ax2_start, ax2_end in zip(ax2_loops[:-1], ax2_loops[1:]):
-            small_sky_cut = _load_rectangular_slice(auf_folder, 'small_', a_astro, ax1_start,
-                                                    ax1_end, ax2_start, ax2_end, 0)
+            small_sky_cut = _load_rectangular_slice('small_', a_astro, ax1_start, ax1_end,
+                                                    ax2_start, ax2_end, 0)
             a_astro_small = a_astro[small_sky_cut]
             if len(a_astro_small) == 0:
                 continue
 
-            overlap_sky_cut = _load_rectangular_slice(auf_folder, '', a_astro_overlap_cut,
-                                                      ax1_start, ax1_end, ax2_start, ax2_end,
-                                                      density_radius)
+            overlap_sky_cut = _load_rectangular_slice('', a_astro_overlap_cut, ax1_start, ax1_end,
+                                                      ax2_start, ax2_end, density_radius)
             cut = np.zeros(dtype=bool, shape=(len(a_astro_overlap_cut),))
             di = max(1, len(cut) // 20)
             for i in range(0, len(a_astro_overlap_cut), di):

--- a/macauff/perturbation_auf.py
+++ b/macauff/perturbation_auf.py
@@ -12,7 +12,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 
 from .misc_functions import (create_auf_params_grid, _load_single_sky_slice,
-                             _load_rectangular_slice, _create_rectangular_slice_arrays, min_max_lon)
+                             _load_rectangular_slice, min_max_lon)
 from .misc_functions_fortran import misc_functions_fortran as mff
 from .get_trilegal_wrapper import get_trilegal, get_AV_infinity
 from .perturbation_auf_fortran import perturbation_auf_fortran as paf

--- a/macauff/photometric_likelihood.py
+++ b/macauff/photometric_likelihood.py
@@ -164,10 +164,8 @@ def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_
                 # opposing view slices into the other catalogue, for each
                 # catalogue. Note that the lengths are swapped in the two calls,
                 # as the a_inds map into length of catalogue "b" and vice versa.
-                a_inds_map, a_inds_cut_unique = map_large_index_to_small_index(
-                    a_inds_cut, len_b, '{}/phot_like'.format(joint_folder_path))
-                b_inds_map, b_inds_cut_unique = map_large_index_to_small_index(
-                    b_inds_cut, len_a, '{}/phot_like'.format(joint_folder_path))
+                a_inds_map, a_inds_cut_unique = map_large_index_to_small_index(a_inds_cut, len_b)
+                b_inds_map, b_inds_cut_unique = map_large_index_to_small_index(b_inds_cut, len_a)
 
                 # Combined with b_inds_map, this subarray of the catalogue gives
                 # an array that has every "a" source that overlaps the "b"

--- a/macauff/photometric_likelihood.py
+++ b/macauff/photometric_likelihood.py
@@ -4,7 +4,6 @@ This module provides the framework for the creation of the photometric likelihoo
 used in the cross-matching of the two catalogues.
 '''
 
-import os
 import sys
 import numpy as np
 

--- a/macauff/photometric_likelihood.py
+++ b/macauff/photometric_likelihood.py
@@ -7,7 +7,7 @@ used in the cross-matching of the two catalogues.
 import sys
 import numpy as np
 
-from .misc_functions import map_large_index_to_small_index, _load_single_sky_slice, StageData
+from .misc_functions import map_large_index_to_small_index, StageData
 from .misc_functions_fortran import misc_functions_fortran as mff
 from .photometric_likelihood_fortran import photometric_likelihood_fortran as plf
 
@@ -15,9 +15,9 @@ __all__ = ['compute_photometric_likelihoods']
 
 
 def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_folder_path,
-                                    afilts, bfilts, mem_chunk_num, cf_points, cf_areas,
-                                    include_phot_like, use_phot_priors, group_sources_data,
-                                    bright_frac=None, field_frac=None):
+                                    afilts, bfilts, cf_points, cf_areas, include_phot_like,
+                                    use_phot_priors, group_sources_data, bright_frac=None,
+                                    field_frac=None):
     '''
     Derives the photometric likelihoods and priors for use in the catalogue
     cross-match process.
@@ -35,9 +35,6 @@ def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_
         A list of the filters in catalogue "a"'s photometric data file.
     bfilts : list of string
         List of catalogue "b"'s filters.
-    mem_chunk_num : integer
-        Fraction of input datasets to load at once, in the case of data larger
-        than the memory of the system.
     cf_points : numpy.ndarray
         The on-sky coordinates that define the locations of each small
         set of sources to be used to derive the relative match and non-match
@@ -76,26 +73,31 @@ def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_
 
     print("Creating c(m, m) and f(m)...")
 
-    len_a = len(np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path), mmap_mode='r'))
-    len_b = len(np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path), mmap_mode='r'))
+    len_a = len(np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path)))
+    len_b = len(np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path)))
 
     print("Distributing sources into sky slices...")
     sys.stdout.flush()
 
-    a_sky_inds = distribute_sky_indices(joint_folder_path, a_cat_folder_path, 'a', mem_chunk_num,
-                                        cf_points)
-    b_sky_inds = distribute_sky_indices(joint_folder_path, b_cat_folder_path, 'b', mem_chunk_num,
-                                        cf_points)
+    a_astro = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path))
+    b_astro = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path))
+    a_photo = np.load('{}/con_cat_photo.npy'.format(a_cat_folder_path))
+    b_photo = np.load('{}/con_cat_photo.npy'.format(b_cat_folder_path))
+
+    a_sky_inds = mff.find_nearest_point(a_astro[:, 0], a_astro[:, 1], cf_points[:, 0],
+                                        cf_points[:, 1])
+    b_sky_inds = mff.find_nearest_point(b_astro[:, 0], b_astro[:, 1], cf_points[:, 0],
+                                        cf_points[:, 1])
 
     print("Making bins...")
     sys.stdout.flush()
 
     abinlengths, abinsarray, longabinlen = create_magnitude_bins(
-        cf_points, afilts, mem_chunk_num, joint_folder_path, a_cat_folder_path, 'a', a_sky_inds,
+        cf_points, afilts, a_photo, joint_folder_path, a_cat_folder_path, 'a', a_sky_inds,
         include_phot_like or use_phot_priors, group_sources_data.ablen,
         group_sources_data.ainds, group_sources_data.asize)
     bbinlengths, bbinsarray, longbbinlen = create_magnitude_bins(
-        cf_points, bfilts, mem_chunk_num, joint_folder_path, b_cat_folder_path, 'b', b_sky_inds,
+        cf_points, bfilts, b_photo, joint_folder_path, b_cat_folder_path, 'b', b_sky_inds,
         include_phot_like or use_phot_priors, group_sources_data.bblen,
         group_sources_data.binds, group_sources_data.bsize)
 
@@ -112,130 +114,103 @@ def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_
     fb_array = np.zeros(dtype=float, shape=(longbbinlen-1, len(bfilts), len(afilts),
                                             len(cf_points)), order='F')
 
-    # Within each loop, since we've already assigned all sources to have a closest
-    # c/f sky position pointing to be assigned to, we simply slice within the _load
-    # functions on ID, and for the initial mem_chunk_num stepping load in the range
-    # [m_, m_+mem_chunk_num).
-    for m_ in range(0, len(cf_points), mem_chunk_num):
-        a_multi_return = _load_multiple_sky_slice('a', m_, m_+mem_chunk_num, a_cat_folder_path,
-                                                  a_sky_inds, include_phot_like or use_phot_priors,
-                                                  group_sources_data.ablen,
-                                                  group_sources_data.ainds, group_sources_data.asize)
+    ablen = group_sources_data.ablen
+    ainds = group_sources_data.ainds
+    binds = group_sources_data.binds
+    asize = group_sources_data.asize
+    bsize = group_sources_data.bsize
+
+    for m in range(0, len(cf_points)):
+        area = cf_areas[m]
+        a_sky_cut = a_sky_inds == m
+        a_photo_cut = a_photo[a_sky_cut]
         if include_phot_like or use_phot_priors:
-            (a_small_photo, a_sky_ind_small, a_small_astro, a_blen_small, a_inds_small,
-             a_size_small) = a_multi_return
-        else:
-            a_small_photo, a_sky_ind_small = a_multi_return
-        del a_multi_return
+            a_astro_cut, a_blen_cut, a_inds_cut, a_size_cut = (
+                a_astro[a_sky_cut], ablen[a_sky_cut], ainds[:, a_sky_cut], asize[a_sky_cut])
 
-        b_multi_return = _load_multiple_sky_slice('b', m_, m_+mem_chunk_num, b_cat_folder_path,
-                                                  b_sky_inds, include_phot_like or use_phot_priors,
-                                                  group_sources_data.bblen,
-                                                  group_sources_data.binds, group_sources_data.bsize)
+        b_sky_cut = b_sky_inds == m
+        b_photo_cut = b_photo[b_sky_cut]
         if include_phot_like or use_phot_priors:
-            (b_small_photo, b_sky_ind_small, b_small_astro, b_blen_small, b_inds_small,
-             b_size_small) = b_multi_return
-            del b_blen_small
-        else:
-            b_small_photo, b_sky_ind_small = b_multi_return
-        del b_multi_return
+            b_astro_cut, b_inds_cut, b_size_cut = (
+                b_astro[b_sky_cut], binds[:, b_sky_cut], bsize[b_sky_cut])
 
-        for m in range(m_, min(len(cf_points), m_+mem_chunk_num)):
-            area = cf_areas[m]
-            a_sky_cut = _load_single_sky_slice('a', m, a_sky_ind_small)
-            a_photo_cut = a_small_photo[a_sky_cut]
-            if include_phot_like or use_phot_priors:
-                a_astro_cut, a_blen_cut, a_inds_cut, a_size_cut = (
-                    a_small_astro[a_sky_cut], a_blen_small[a_sky_cut], a_inds_small[:, a_sky_cut],
-                    a_size_small[a_sky_cut])
+            # Return the overall to subarray mapping of *_inds_cut, as well
+            # as the unique values of *_inds_cut, for use in creating the
+            # opposing view slices into the other catalogue, for each
+            # catalogue. Note that the lengths are swapped in the two calls,
+            # as the a_inds map into length of catalogue "b" and vice versa.
+            a_inds_map, a_inds_cut_unique = map_large_index_to_small_index(a_inds_cut, len_b)
+            b_inds_map, b_inds_cut_unique = map_large_index_to_small_index(b_inds_cut, len_a)
 
-            b_sky_cut = _load_single_sky_slice('b', m, b_sky_ind_small)
-            b_photo_cut = b_small_photo[b_sky_cut]
-            if include_phot_like or use_phot_priors:
-                b_astro_cut, b_inds_cut, b_size_cut = (
-                    b_small_astro[b_sky_cut], b_inds_small[:, b_sky_cut], b_size_small[b_sky_cut])
+            # Combined with b_inds_map, this subarray of the catalogue gives
+            # an array that has every "a" source that overlaps the "b"
+            # subarray objects. Note we use b_inds_cut_unique for catalogue
+            # "a" sources.
+            a_astro_ind = a_astro[b_inds_cut_unique]
+            b_astro_ind = b_astro[a_inds_cut_unique]
+            a_photo_ind = a_photo[b_inds_cut_unique]
+            b_photo_ind = b_photo[a_inds_cut_unique]
 
-                # Return the overall to subarray mapping of *_inds_cut, as well
-                # as the unique values of *_inds_cut, for use in creating the
-                # opposing view slices into the other catalogue, for each
-                # catalogue. Note that the lengths are swapped in the two calls,
-                # as the a_inds map into length of catalogue "b" and vice versa.
-                a_inds_map, a_inds_cut_unique = map_large_index_to_small_index(a_inds_cut, len_b)
-                b_inds_map, b_inds_cut_unique = map_large_index_to_small_index(b_inds_cut, len_a)
+            a_flen_ind = group_sources_data.aflen[b_inds_cut_unique]
+            b_flen_ind = group_sources_data.bflen[a_inds_cut_unique]
 
-                # Combined with b_inds_map, this subarray of the catalogue gives
-                # an array that has every "a" source that overlaps the "b"
-                # subarray objects. Note we use b_inds_cut_unique for catalogue
-                # "a" sources.
-                a_astro_ind = np.load('{}/con_cat_astro.npy'.format(a_cat_folder_path),
-                                      mmap_mode='r')[b_inds_cut_unique]
-                b_astro_ind = np.load('{}/con_cat_astro.npy'.format(b_cat_folder_path),
-                                      mmap_mode='r')[a_inds_cut_unique]
-                a_photo_ind = np.load('{}/con_cat_photo.npy'.format(a_cat_folder_path),
-                                      mmap_mode='r')[b_inds_cut_unique]
-                b_photo_ind = np.load('{}/con_cat_photo.npy'.format(b_cat_folder_path),
-                                      mmap_mode='r')[a_inds_cut_unique]
-
-                a_flen_ind = group_sources_data.aflen[b_inds_cut_unique]
-                b_flen_ind = group_sources_data.bflen[a_inds_cut_unique]
-
-            for i in range(0, len(afilts)):
+        for i in range(0, len(afilts)):
+            if not include_phot_like and not use_phot_priors:
+                a_num_photo_cut = np.sum(~np.isnan(a_photo_cut[:, i]))
+                Na = a_num_photo_cut / area
+            else:
+                a_bins = abinsarray[:abinlengths[i, m], i, m]
+                a_mag = a_photo_cut[:, i]
+                a_flags = ~np.isnan(a_mag)
+                a_flags_ind = ~np.isnan(a_photo_ind[:, i])
+            for j in range(0, len(bfilts)):
                 if not include_phot_like and not use_phot_priors:
-                    a_num_photo_cut = np.sum(~np.isnan(a_photo_cut[:, i]))
-                    Na = a_num_photo_cut / area
+                    b_num_photo_cut = np.sum(~np.isnan(b_photo_cut[:, j]))
+                    Nb = b_num_photo_cut / area
+                    # Without using photometric-based priors, all we can
+                    # do is set the prior on one catalogue to 0.5 -- that
+                    # is, equal chance of match or non-match; for this we
+                    # use the less dense of the two catalogues as our
+                    # "one-sided" match. Then, accordingly, we update the
+                    # "field" source density of the more dense catalogue
+                    # with its corresponding density, based on the input
+                    # density and the counterpart density calculated.
+                    c_prior = min(Na, Nb) / 2
+                    fa_prior = Na - c_prior
+                    fb_prior = Nb - c_prior
+                    # To fake no photometric likelihoods, simply set all
+                    # values to one, to cancel in the ratio later.
+                    c_like, fa_like, fb_like = (1-1e-10)**2, 1-1e-10, 1-1e-10
                 else:
-                    a_bins = abinsarray[:abinlengths[i, m], i, m]
-                    a_mag = a_photo_cut[:, i]
-                    a_flags = ~np.isnan(a_mag)
-                    a_flags_ind = ~np.isnan(a_photo_ind[:, i])
-                for j in range(0, len(bfilts)):
-                    if not include_phot_like and not use_phot_priors:
-                        b_num_photo_cut = np.sum(~np.isnan(b_photo_cut[:, j]))
-                        Nb = b_num_photo_cut / area
-                        # Without using photometric-based priors, all we can
-                        # do is set the prior on one catalogue to 0.5 -- that
-                        # is, equal chance of match or non-match; for this we
-                        # use the less dense of the two catalogues as our
-                        # "one-sided" match. Then, accordingly, we update the
-                        # "field" source density of the more dense catalogue
-                        # with its corresponding density, based on the input
-                        # density and the counterpart density calculated.
-                        c_prior = min(Na, Nb) / 2
-                        fa_prior = Na - c_prior
-                        fb_prior = Nb - c_prior
-                        # To fake no photometric likelihoods, simply set all
-                        # values to one, to cancel in the ratio later.
-                        c_like, fa_like, fb_like = (1-1e-10)**2, 1-1e-10, 1-1e-10
-                    else:
-                        b_bins = bbinsarray[:bbinlengths[j, m], j, m]
-                        b_mag = b_photo_cut[:, j]
-                        b_flags = ~np.isnan(b_mag)
-                        b_mag_ind = b_photo_ind[:, j]
-                        b_flags_ind = ~np.isnan(b_mag_ind)
+                    b_bins = bbinsarray[:bbinlengths[j, m], j, m]
+                    b_mag = b_photo_cut[:, j]
+                    b_flags = ~np.isnan(b_mag)
+                    b_mag_ind = b_photo_ind[:, j]
+                    b_flags_ind = ~np.isnan(b_mag_ind)
 
-                        c_prior, c_like, fa_prior, fa_like, fb_prior, fb_like = create_c_and_f(
-                            a_astro_cut, b_astro_cut, a_mag, b_mag, a_inds_map, a_size_cut,
-                            b_inds_map, b_size_cut, a_blen_cut, a_bins, b_bins, bright_frac,
-                            field_frac, a_flags, b_flags, a_astro_ind, b_astro_ind, a_flen_ind,
-                            b_flen_ind, a_flags_ind, b_flags_ind, b_mag_ind, area)
-                    if use_phot_priors and not include_phot_like:
-                        # If we only used the create_c_and_f routine to derive
-                        # priors, then quickly update likelihoods here.
-                        c_like, fa_like, fb_like = (1-1e-10)**2, 1-1e-10, 1-1e-10
+                    c_prior, c_like, fa_prior, fa_like, fb_prior, fb_like = create_c_and_f(
+                        a_astro_cut, b_astro_cut, a_mag, b_mag, a_inds_map, a_size_cut,
+                        b_inds_map, b_size_cut, a_blen_cut, a_bins, b_bins, bright_frac,
+                        field_frac, a_flags, b_flags, a_astro_ind, b_astro_ind, a_flen_ind,
+                        b_flen_ind, a_flags_ind, b_flags_ind, b_mag_ind, area)
+                if use_phot_priors and not include_phot_like:
+                    # If we only used the create_c_and_f routine to derive
+                    # priors, then quickly update likelihoods here.
+                    c_like, fa_like, fb_like = (1-1e-10)**2, 1-1e-10, 1-1e-10
 
-                    # Have to add a very small "fire extinguisher" value to all
-                    # likelihoods and priors, to avoid ever having exactly zero
-                    # value in either, which would mean all island permutations
-                    # were rejected.
-                    c_priors[j, i, m] = c_prior + 1e-100
-                    fa_priors[j, i, m] = fa_prior + 1e-10
-                    fb_priors[j, i, m] = fb_prior + 1e-10
-                    # c should be equal to f^2 in the limit of indifference, so
-                    # add 1e-10 and (1e-10)^2 to f and c respectively.
-                    c_array[:bbinlengths[j, m]-1,
-                            :abinlengths[i, m]-1, j, i, m] = c_like + 1e-100
-                    fa_array[:abinlengths[i, m]-1, j, i, m] = fa_like + 1e-10
-                    fb_array[:bbinlengths[j, m]-1, j, i, m] = fb_like + 1e-10
+                # Have to add a very small "fire extinguisher" value to all
+                # likelihoods and priors, to avoid ever having exactly zero
+                # value in either, which would mean all island permutations
+                # were rejected.
+                c_priors[j, i, m] = c_prior + 1e-100
+                fa_priors[j, i, m] = fa_prior + 1e-10
+                fb_priors[j, i, m] = fb_prior + 1e-10
+                # c should be equal to f^2 in the limit of indifference, so
+                # add 1e-10 and (1e-10)^2 to f and c respectively.
+                c_array[:bbinlengths[j, m]-1,
+                        :abinlengths[i, m]-1, j, i, m] = c_like + 1e-100
+                fa_array[:abinlengths[i, m]-1, j, i, m] = fa_like + 1e-10
+                fb_array[:bbinlengths[j, m]-1, j, i, m] = fb_like + 1e-10
 
     phot_like_data = StageData(abinsarray=abinsarray, abinlengths=abinlengths,
                                bbinsarray=bbinsarray, bbinlengths=bbinlengths,
@@ -246,49 +221,7 @@ def compute_photometric_likelihoods(joint_folder_path, a_cat_folder_path, b_cat_
     return phot_like_data
 
 
-def distribute_sky_indices(joint_folder_path, cat_folder, name, mem_chunk_num, cf_points):
-    '''
-    Function to calculate the nearest on-sky photometric likelihood point for
-    each catalogue source.
-
-    Parameters
-    ----------
-    joint_folder_path : string
-        Top-level folder path for the common files created during the cross-match
-        process.
-    cat_folder : string
-        The location of a given catalogue's input data files.
-    name : string
-        Representation of whether we are calculating sky indices for catalogue
-        "a", or catalogue "b".
-    mem_chunk_num : integer
-        Number of sub-sets to break larger data files down to, to preserve memory.
-    cf_points : numpy.ndarray
-        The two-point sky coordinates for each point to be used as a central
-        point of a small sky area, for calculating "counterpart" and "field"
-        photometric likelihoods.
-
-    Returns
-    -------
-    sky_inds : numpy.ndarray
-        The indices, matching ``cf_points``, of the closest sky position for each
-        source in this catalogue.
-    '''
-    n_sources = len(np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r'))
-    sky_inds = np.zeros(dtype=int, shape=(n_sources,), order='F')
-    for cnum in range(0, mem_chunk_num):
-        lowind = np.floor(n_sources*cnum/mem_chunk_num).astype(int)
-        highind = np.floor(n_sources*(cnum+1)/mem_chunk_num).astype(int)
-        a = np.load('{}/con_cat_astro.npy'.format(cat_folder), mmap_mode='r')[lowind:highind]
-        # Haversine doesn't mind 0-360 wraparound so a can be in [0, 360] range
-        # but cf_points in the negative-to-positive cutout.
-        sky_inds[lowind:highind] = mff.find_nearest_point(a[:, 0], a[:, 1],
-                                                          cf_points[:, 0], cf_points[:, 1])
-
-    return sky_inds
-
-
-def create_magnitude_bins(cf_points, filts, mem_chunk_num, joint_folder_path,
+def create_magnitude_bins(cf_points, filts, a_photo, joint_folder_path,
                           cat_folder_path, cat_type, sky_inds, load_extra_arrays,
                           blen_cutout, inds_cutout, size_cutout):
     '''
@@ -303,9 +236,8 @@ def create_magnitude_bins(cf_points, filts, mem_chunk_num, joint_folder_path,
         calculated.
     filts : list of strings
         List of the filters to create magnitude bins for in this catalogue.
-    mem_chunk_num : integer
-        Number of sub-sets to break larger catalogues down into, for memory
-        saving purposes.
+    a_photo : numpy.ndarray
+        Photometric detections from which to create magnitude bins.
     joint_folder_path : string
         Location of top-level folder into which all intermediate files are
         saved for the cross-match process.
@@ -340,47 +272,30 @@ def create_magnitude_bins(cf_points, filts, mem_chunk_num, joint_folder_path,
     '''
     binlengths = np.empty((len(filts), len(cf_points)), int)
 
-    for m_ in range(0, len(cf_points), mem_chunk_num):
-        a_multi_return = _load_multiple_sky_slice(cat_type, m_, m_+mem_chunk_num, cat_folder_path,
-                                                  sky_inds, load_extra_arrays, blen_cutout,
-                                                  inds_cutout, size_cutout)
-        if load_extra_arrays:
-            (a_phot_, sky_inds_, _, _, _, _) = a_multi_return
-        else:
-            a_phot_, sky_inds_ = a_multi_return
-        del a_multi_return
-        for m in range(m_, min(len(cf_points), m_+mem_chunk_num)):
-            sky_cut = _load_single_sky_slice(cat_type, m, sky_inds_)
-            for i in range(0, len(filts)):
-                a = a_phot_[sky_cut, i]
-                if np.sum(~np.isnan(a)) > 0:
-                    f = make_bins(a[~np.isnan(a)])
-                else:
-                    f = np.array([0])
-                del a
-                binlengths[i, m] = len(f)
+    for m in range(0, len(cf_points)):
+        sky_cut = sky_inds == m
+        for i in range(0, len(filts)):
+            a = a_photo[sky_cut, i]
+            if np.sum(~np.isnan(a)) > 0:
+                f = make_bins(a[~np.isnan(a)])
+            else:
+                f = np.array([0])
+            del a
+            binlengths[i, m] = len(f)
 
     longbinlen = np.amax(binlengths)
 
     binsarray = np.full(dtype=float, shape=(longbinlen, len(filts), len(cf_points)), fill_value=-1, order='F')
-    for m_ in range(0, len(cf_points), mem_chunk_num):
-        a_multi_return = _load_multiple_sky_slice(cat_type, m_, m_+mem_chunk_num, cat_folder_path,
-                                                  sky_inds, load_extra_arrays, blen_cutout,
-                                                  inds_cutout, size_cutout)
-        if load_extra_arrays:
-            (a_phot_, sky_inds_, _, _, _, _) = a_multi_return
-        else:
-            a_phot_, sky_inds_ = a_multi_return
-        for m in range(m_, min(len(cf_points), m_+mem_chunk_num)):
-            sky_cut = _load_single_sky_slice(cat_type, m, sky_inds_)
-            for i in range(0, len(filts)):
-                a = a_phot_[sky_cut, i]
-                if np.sum(~np.isnan(a)) > 0:
-                    f = make_bins(a[~np.isnan(a)])
-                else:
-                    f = np.array([0])
-                del a
-                binsarray[:binlengths[i, m], i, m] = f
+    for m in range(0, len(cf_points)):
+        sky_cut = sky_inds == m
+        for i in range(0, len(filts)):
+            a = a_photo[sky_cut, i]
+            if np.sum(~np.isnan(a)) > 0:
+                f = make_bins(a[~np.isnan(a)])
+            else:
+                f = np.array([0])
+            del a
+            binsarray[:binlengths[i, m], i, m] = f
 
     return binlengths, binsarray, longbinlen
 
@@ -440,83 +355,6 @@ def make_bins(input_mags):
     output_bins = np.delete(output_bins, dellist)
 
     return output_bins
-
-
-def _load_multiple_sky_slice(cat_name, ind1, ind2, cat_folder_path, sky_inds, load_extra_arrays,
-                             blen_tocut, inds_tocut, size_tocut):
-    '''
-    Function to return a sub-set of the photometry
-    of a given catalogue.
-
-    Parameters
-    ----------
-    cat_name : string
-        String defining whether this function was called on catalogue "a" or "b".
-    ind1 : float
-        The lower of the two sky indices, as defined in ``distribute_sky_indices``,
-        to return a sub-set of the larger catalogue between. This value represents
-        the index of a given on-sky position, used to construct the "counterpart"
-        and "field" likelihoods.
-    ind2 : float
-        The upper of the sky indices, defining the sub-set of the photometric
-        array to return.
-    cat_folder_path : string
-        The folder defining where this particular catalogue is stored.
-    sky_inds : numpy.ndarray
-        The given catalogue's ``distribute_sky_indices`` values, to compare
-        with ``ind1`` and ``ind2``.
-    load_extra_arrays : boolean
-        Flag to indicate whether the photometric information is being used in
-        the cross-match process, and whether to load additional arrays accordingly.
-    blen_tocut : numpy.ndarray
-        Output from ``group_sources``. Used only when ``load_extra_arrays`` is True.
-    inds_tocut : numpy.ndarray
-        Output from ``group_sources``. Used only when ``load_extra_arrays`` is True.
-    size_tocut : numpy.ndarray
-        Output from ``group_sources``. Used only when ``load_extra_arrays`` is True.
-
-    Returns
-    -------
-    photo_cutout : numpy.ndarray
-        A sub-set of the photometry of the given catalogue, those points which are
-        astrometrically closest to the sky indices between ``ind1`` and ``ind2``.
-    sky_ind_cutout : numpy.ndarray
-        The reduced ``sky_inds`` array, containing only those between ``ind1`` and
-        ``ind2``.
-    list_of_arrays : list of numpy.ndarrays
-        Depending on whether ``load_extra_arrays`` is ``True`` or not, this list
-        contains either just a cutout of the photometric data for this catalogue
-        and the corresponding subset of the sky index array, or it also contains
-        subsets of the astrometry array, and "bright" source error circle length,
-        and overlap index and size arrays.
-    '''
-    sky_cut = np.zeros(dtype=bool, shape=(len(sky_inds),))
-
-    di = max(1, len(sky_inds) // 20)
-
-    for i in range(0, len(sky_inds), di):
-        sky_cut[i:i+di] = (sky_inds[i:i+di] >= ind1) & (sky_inds[i:i+di] < ind2)
-
-    if load_extra_arrays:
-        astro_cutout = np.load('{}/con_cat_astro.npy'.format(cat_folder_path),
-                               mmap_mode='r')[sky_cut]
-
-        a_blen_cutout = blen_tocut[sky_cut]
-        a_inds_cutout = inds_tocut[:, sky_cut]
-        a_size_cutout = size_tocut[sky_cut]
-
-    photo_cutout = np.load('{}/con_cat_photo.npy'.format(cat_folder_path), mmap_mode='r')[sky_cut]
-    sky_ind_cutout = sky_inds[sky_cut]
-
-    if load_extra_arrays:
-        list_of_arrays = (photo_cutout, sky_ind_cutout, astro_cutout, a_blen_cutout, a_inds_cutout,
-                          a_size_cutout)
-    else:
-        list_of_arrays = (photo_cutout, sky_ind_cutout)
-
-    del sky_cut
-
-    return list_of_arrays
 
 
 def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_blen,

--- a/macauff/tests/data/crossmatch_params.txt
+++ b/macauff/tests/data/crossmatch_params.txt
@@ -9,12 +9,6 @@ joint_folder_path = test_path
 
 make_output_csv = no
 
-# Flags for each stage of the match process - must be "yes"/"no", "true"/"false", "t"/"f", or "1"/"0"
-run_auf = no
-run_group = no
-run_cf = yes
-run_source = yes
-
 # c/f region definition for photometric likelihood - either "rectangle" for NxM evenly spaced grid points, or "points" to define a list of two-point tuple coordinates, separated by a comma
 cf_region_type = rectangle
 # Frame of the coordinates must be specified -- either "equatorial" or "galactic"

--- a/macauff/tests/data/crossmatch_params.txt
+++ b/macauff/tests/data/crossmatch_params.txt
@@ -41,8 +41,6 @@ int_fracs = 0.63 0.9 0.99
 num_trials = 10000
 # Bin size of magnitudes for number density distributions for perturbation AUF considersation
 d_mag = 0.1
-# Flag to indicate whether to use pre-computed local normalising densities for simulating PSFs
-compute_local_density = no
 
 # Multiprocessing CPU count
 n_pool = 2

--- a/macauff/tests/data/crossmatch_params.txt
+++ b/macauff/tests/data/crossmatch_params.txt
@@ -31,9 +31,6 @@ four_max_rho = 100
 # Maximum extent of cross-match, used in non-all-sky cases to remove sources suffering potential edge effects -- min/max first axis coordinates (ra/l) then min/max second axis coordinates (dec/b)
 cross_match_extent = 131 138 -3 3
 
-# Number of chunks to break each catalogue into when splitting larger catalogues up for memory reasons
-mem_chunk_num = 10
-
 # Integral fractions for various error circle cutouts used during the cross-match process. Should be space-separated floats, in the order of <bright error circle fraction>, <field error circle fraction>, <potential counterpart integral limit>
 int_fracs = 0.63 0.9 0.99
 

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -144,31 +144,8 @@ class TestCounterpartPairing:
         np.save('{}/magref.npy'.format(self.a_cat_folder_path), self.amagref)
         np.save('{}/magref.npy'.format(self.b_cat_folder_path), self.bmagref)
 
-        np.save('{}/group/alist.npy'.format(self.joint_folder_path), self.alist)
-        np.save('{}/group/blist.npy'.format(self.joint_folder_path), self.blist)
-        np.save('{}/group/agrplen.npy'.format(self.joint_folder_path), self.agrplen)
-        np.save('{}/group/bgrplen.npy'.format(self.joint_folder_path), self.bgrplen)
-
-        np.save('{}/phot_like/abinsarray.npy'.format(self.joint_folder_path), self.abinsarray)
-        np.save('{}/phot_like/bbinsarray.npy'.format(self.joint_folder_path), self.bbinsarray)
-        np.save('{}/phot_like/abinlengths.npy'.format(self.joint_folder_path), self.abinlengths)
-        np.save('{}/phot_like/bbinlengths.npy'.format(self.joint_folder_path), self.bbinlengths)
-
-        np.save('{}/phot_like/c_priors.npy'.format(self.joint_folder_path), self.c_priors)
-        np.save('{}/phot_like/c_array.npy'.format(self.joint_folder_path), self.c_array)
-        np.save('{}/phot_like/fa_priors.npy'.format(self.joint_folder_path), self.fa_priors)
-        np.save('{}/phot_like/fa_array.npy'.format(self.joint_folder_path), self.fa_array)
-        np.save('{}/phot_like/fb_priors.npy'.format(self.joint_folder_path), self.fb_priors)
-        np.save('{}/phot_like/fb_array.npy'.format(self.joint_folder_path), self.fb_array)
-
-        np.save('{}/phot_like/a_sky_inds.npy'.format(self.joint_folder_path), self.a_sky_inds)
-        np.save('{}/phot_like/b_sky_inds.npy'.format(self.joint_folder_path), self.b_sky_inds)
-
         np.save('{}/modelrefinds.npy'.format(self.a_auf_folder_path), self.amodelrefinds)
         np.save('{}/modelrefinds.npy'.format(self.b_auf_folder_path), self.bmodelrefinds)
-
-        np.save('{}/arraylengths.npy'.format(self.a_auf_folder_path), np.ones((3, 1), int))
-        np.save('{}/arraylengths.npy'.format(self.b_auf_folder_path), np.ones((4, 1), int))
 
         # We should have already made fourier_grid, frac_grid, and flux_grid
         # for each catalogue.
@@ -397,13 +374,6 @@ class TestCounterpartPairing:
 
         os.system('rm -r {}/reject'.format(self.joint_folder_path))
         os.makedirs('{}/reject'.format(self.joint_folder_path), exist_ok=True)
-        np.save('{}/reject/reject_a.npy'.format(self.joint_folder_path), a_reject)
-        np.save('{}/reject/reject_b.npy'.format(self.joint_folder_path), b_reject)
-
-        np.save('{}/group/alist.npy'.format(self.joint_folder_path), alist)
-        np.save('{}/group/blist.npy'.format(self.joint_folder_path), blist)
-        np.save('{}/group/agrplen.npy'.format(self.joint_folder_path), agrplen)
-        np.save('{}/group/bgrplen.npy'.format(self.joint_folder_path), bgrplen)
 
         mem_chunk_num = 2
         source_pairing(
@@ -475,14 +445,6 @@ class TestCounterpartPairing:
             alist=alist, blist=blist, agrplen=agrplen, bgrplen=bgrplen,
             lenrejecta=len(a_reject), lenrejectb=0)
 
-        np.save('{}/reject/reject_a.npy'.format(self.joint_folder_path), a_reject)
-        os.system('rm {}/reject/reject_b.npy'.format(self.joint_folder_path))
-
-        np.save('{}/group/alist.npy'.format(self.joint_folder_path), alist)
-        np.save('{}/group/blist.npy'.format(self.joint_folder_path), blist)
-        np.save('{}/group/agrplen.npy'.format(self.joint_folder_path), agrplen)
-        np.save('{}/group/bgrplen.npy'.format(self.joint_folder_path), bgrplen)
-
         mem_chunk_num = 2
         with pytest.warns(UserWarning) as record:
             source_pairing(
@@ -505,10 +467,6 @@ class TestCounterpartPairing:
         a_field = np.load('{}/pairing/af.npy'.format(self.joint_folder_path))
         assert np.all([q in a_field for q in [3, 4]])
         assert np.all([q not in a_field for q in [0, 1, 2, 5, 6]])
-
-        a_reject = np.load('{}/reject/reject_a.npy'.format(self.joint_folder_path))
-        assert np.all([q in a_reject for q in [6]])
-        assert np.all([q not in a_reject for q in [0, 1, 2, 3, 4, 5]])
 
         b_matches = np.load('{}/pairing/bc.npy'.format(self.joint_folder_path))
         assert np.all([q in b_matches for q in [0, 1]])
@@ -538,14 +496,6 @@ class TestCounterpartPairing:
             alist=alist, blist=blist, agrplen=agrplen, bgrplen=bgrplen,
             lenrejecta=len(a_reject), lenrejectb=len(b_reject))
 
-        np.save('{}/reject/reject_a.npy'.format(self.joint_folder_path), a_reject)
-        np.save('{}/reject/reject_b.npy'.format(self.joint_folder_path), b_reject)
-
-        np.save('{}/group/alist.npy'.format(self.joint_folder_path), alist)
-        np.save('{}/group/blist.npy'.format(self.joint_folder_path), blist)
-        np.save('{}/group/agrplen.npy'.format(self.joint_folder_path), agrplen)
-        np.save('{}/group/bgrplen.npy'.format(self.joint_folder_path), bgrplen)
-
         mem_chunk_num = 2
         with pytest.warns(UserWarning) as record:
             source_pairing(
@@ -568,10 +518,6 @@ class TestCounterpartPairing:
         a_field = np.load('{}/pairing/af.npy'.format(self.joint_folder_path))
         assert np.all([q in a_field for q in [3, 4]])
         assert np.all([q not in a_field for q in [0, 1, 2, 5, 6]])
-
-        a_reject = np.load('{}/reject/reject_a.npy'.format(self.joint_folder_path))
-        assert np.all([q in a_reject for q in [2, 3, 4, 5, 6]])
-        assert np.all([q not in a_reject for q in [0, 1]])
 
         b_matches = np.load('{}/pairing/bc.npy'.format(self.joint_folder_path))
         assert np.all([q in b_matches for q in [0, 1]])
@@ -608,10 +554,6 @@ class TestCounterpartPairing:
         os.system('rm -r {}/pairing'.format(self.joint_folder_path))
         os.makedirs('{}/pairing'.format(self.joint_folder_path), exist_ok=True)
         os.system('rm -r {}/reject/*'.format(self.joint_folder_path))
-        np.save('{}/group/alist.npy'.format(self.joint_folder_path), self.alist)
-        np.save('{}/group/blist.npy'.format(self.joint_folder_path), self.blist)
-        np.save('{}/group/agrplen.npy'.format(self.joint_folder_path), self.agrplen)
-        np.save('{}/group/bgrplen.npy'.format(self.joint_folder_path), self.bgrplen)
         # Same run as test_source_pairing, but called from CrossMatch rather than
         # directly this time.
         self._setup_cross_match_parameters()

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -132,8 +132,7 @@ class TestCounterpartPairing:
             fb_priors=self.fb_priors, fb_array=self.fb_array)
 
         os.system('rm -r {}'.format(self.joint_folder_path))
-        for f in ['pairing', 'phot_like', 'group']:
-            os.makedirs('{}/{}'.format(self.joint_folder_path, f), exist_ok=True)
+        os.makedirs('{}/pairing'.format(self.joint_folder_path), exist_ok=True)
         for f in [self.a_cat_folder_path, self.b_cat_folder_path,
                   self.a_auf_folder_path, self.b_auf_folder_path]:
             os.makedirs(f, exist_ok=True)

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -72,9 +72,7 @@ class TestCounterpartPairing:
         self.b_photo = np.ones((4, 4), float)
 
         self.alist = np.array([[0, 3], [1, 4], [2, 5], [6, -1], [-1, -1]]).T
-        self.alist_ = self.alist
         self.blist = np.array([[1], [0], [3], [-1], [2]]).T
-        self.blist_ = self.blist
         self.agrplen = np.array([2, 2, 2, 1, 0])
         self.bgrplen = np.array([1, 1, 1, 0, 1])
 
@@ -185,7 +183,6 @@ class TestCounterpartPairing:
             self.aflux_grids, self.afourier_grids, self.bfrac_grids, self.bflux_grids,
             self.bfourier_grids, self.rho, self.drho, self.n_fracs, self.large_len,
             self.alist[:self.agrplen[i], i]+1, self.blist[:self.bgrplen[i], i]+1,
-            self.alist_[:self.agrplen[i], i], self.blist_[:self.bgrplen[i], i],
             self.amagref[self.alist[:self.agrplen[i], i]]+1,
             self.a_sky_inds[self.alist[:self.agrplen[i], i]]+1,
             self.bmagref[self.blist[:self.bgrplen[i], i]]+1,
@@ -236,7 +233,6 @@ class TestCounterpartPairing:
             self.aflux_grids, self.afourier_grids, self.bfrac_grids, self.bflux_grids,
             self.bfourier_grids, self.rho, self.drho, self.n_fracs, self.large_len,
             self.alist[:self.agrplen[i], i]+1, self.blist[:self.bgrplen[i], i]+1,
-            self.alist_[:self.agrplen[i], i], self.blist_[:self.bgrplen[i], i],
             self.amagref[self.alist[:self.agrplen[i], i]]+1,
             self.a_sky_inds[self.alist[:self.agrplen[i], i]]+1,
             self.bmagref[self.blist[:self.bgrplen[i], i]]+1,
@@ -260,7 +256,6 @@ class TestCounterpartPairing:
             self.aflux_grids, self.afourier_grids, self.bfrac_grids, self.bflux_grids,
             self.bfourier_grids, self.rho, self.drho, self.n_fracs, self.large_len,
             self.alist[:self.agrplen[i], i]+1, self.blist[:self.bgrplen[i], i]+1,
-            self.alist_[:self.agrplen[i], i], self.blist_[:self.bgrplen[i], i],
             self.amagref[self.alist[:self.agrplen[i], i]]+1,
             self.a_sky_inds[self.alist[:self.agrplen[i], i]]+1,
             self.bmagref[self.blist[:self.bgrplen[i], i]]+1,
@@ -281,12 +276,11 @@ class TestCounterpartPairing:
     def test_source_pairing(self):
         os.system('rm -r {}/pairing'.format(self.joint_folder_path))
         os.makedirs('{}/pairing'.format(self.joint_folder_path), exist_ok=True)
-        mem_chunk_num = 2
         source_pairing(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
             self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
             self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
-            mem_chunk_num, group_sources_data=self.group_sources_data,
+            group_sources_data=self.group_sources_data,
             phot_like_data=self.phot_like_data, a_perturb_auf_outputs=self.a_perturb_auf_outputs,
             b_perturb_auf_outputs=self.b_perturb_auf_outputs)
 
@@ -374,12 +368,11 @@ class TestCounterpartPairing:
         os.system('rm -r {}/reject'.format(self.joint_folder_path))
         os.makedirs('{}/reject'.format(self.joint_folder_path), exist_ok=True)
 
-        mem_chunk_num = 2
         source_pairing(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
             self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
             self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
-            mem_chunk_num, group_sources_data=group_sources_data,
+            group_sources_data=group_sources_data,
             phot_like_data=self.phot_like_data, a_perturb_auf_outputs=self.a_perturb_auf_outputs,
             b_perturb_auf_outputs=self.b_perturb_auf_outputs)
 
@@ -445,13 +438,12 @@ class TestCounterpartPairing:
             alist=alist, blist=blist, agrplen=agrplen, bgrplen=bgrplen,
             lenrejecta=len(a_reject), lenrejectb=0)
 
-        mem_chunk_num = 2
         with pytest.warns(UserWarning) as record:
             source_pairing(
                 self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
                 self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
                 self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
-                mem_chunk_num, group_sources_data=group_sources_data,
+                group_sources_data=group_sources_data,
                 phot_like_data=self.phot_like_data,
                 a_perturb_auf_outputs=self.a_perturb_auf_outputs,
                 b_perturb_auf_outputs=self.b_perturb_auf_outputs)
@@ -498,13 +490,12 @@ class TestCounterpartPairing:
             alist=alist, blist=blist, agrplen=agrplen, bgrplen=bgrplen,
             lenrejecta=len(a_reject), lenrejectb=len(b_reject))
 
-        mem_chunk_num = 2
         with pytest.warns(UserWarning) as record:
             source_pairing(
                 self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
                 self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
                 self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
-                mem_chunk_num, group_sources_data=group_sources_data,
+                group_sources_data=group_sources_data,
                 phot_like_data=self.phot_like_data,
                 a_perturb_auf_outputs=self.a_perturb_auf_outputs,
                 b_perturb_auf_outputs=self.b_perturb_auf_outputs)
@@ -535,8 +526,8 @@ class TestCounterpartPairing:
         # Ensure output chunk directory exists
         os.makedirs(os.path.join(os.path.dirname(__file__), "data/chunk0"), exist_ok=True)
 
-        for ol, nl in zip(['cf_region_points = 131 134 4 -1 1 3', 'mem_chunk_num = 10'],
-                          ['cf_region_points = 131 131 1 0 0 1\n', 'mem_chunk_num = 2\n']):
+        for ol, nl in zip(['cf_region_points = 131 134 4 -1 1 3'],
+                          ['cf_region_points = 131 131 1 0 0 1\n']):
             f = open(os.path.join(os.path.dirname(__file__),
                                   'data/crossmatch_params.txt')).readlines()
             idx = np.where([ol in line for line in f])[0][0]

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -144,17 +144,16 @@ class TestCounterpartPairing:
         np.save('{}/magref.npy'.format(self.a_cat_folder_path), self.amagref)
         np.save('{}/magref.npy'.format(self.b_cat_folder_path), self.bmagref)
 
-        np.save('{}/modelrefinds.npy'.format(self.a_auf_folder_path), self.amodelrefinds)
-        np.save('{}/modelrefinds.npy'.format(self.b_auf_folder_path), self.bmodelrefinds)
-
         # We should have already made fourier_grid, frac_grid, and flux_grid
         # for each catalogue.
-        np.save('{}/fourier_grid.npy'.format(self.a_auf_folder_path), self.afourier_grids)
-        np.save('{}/fourier_grid.npy'.format(self.b_auf_folder_path), self.bfourier_grids)
-        np.save('{}/frac_grid.npy'.format(self.a_auf_folder_path), self.afrac_grids)
-        np.save('{}/frac_grid.npy'.format(self.b_auf_folder_path), self.bfrac_grids)
-        np.save('{}/flux_grid.npy'.format(self.a_auf_folder_path), self.aflux_grids)
-        np.save('{}/flux_grid.npy'.format(self.b_auf_folder_path), self.bflux_grids)
+        self.a_perturb_auf_outputs = {}
+        self.b_perturb_auf_outputs = {}
+        self.a_perturb_auf_outputs['fourier_grid'] = self.afourier_grids
+        self.b_perturb_auf_outputs['fourier_grid'] = self.bfourier_grids
+        self.a_perturb_auf_outputs['frac_grid'] = self.afrac_grids
+        self.b_perturb_auf_outputs['frac_grid'] = self.bfrac_grids
+        self.a_perturb_auf_outputs['flux_grid'] = self.aflux_grids
+        self.b_perturb_auf_outputs['flux_grid'] = self.bflux_grids
 
         self.a_auf_pointings = np.array([[0.0, 0.0]])
         self.b_auf_pointings = np.array([[0.0, 0.0]])
@@ -286,10 +285,11 @@ class TestCounterpartPairing:
         mem_chunk_num = 2
         source_pairing(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-            self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names, self.b_filt_names,
-            self.a_auf_pointings, self.b_auf_pointings, self.amodelrefinds, self.bmodelrefinds,
-            self.rho, self.drho, self.n_fracs, mem_chunk_num,
-            group_sources_data=self.group_sources_data, phot_like_data=self.phot_like_data)
+            self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
+            self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
+            mem_chunk_num, group_sources_data=self.group_sources_data,
+            phot_like_data=self.phot_like_data, a_perturb_auf_outputs=self.a_perturb_auf_outputs,
+            b_perturb_auf_outputs=self.b_perturb_auf_outputs)
 
         bflux = np.load('{}/pairing/bcontamflux.npy'.format(self.joint_folder_path))
         assert np.all(bflux == np.zeros((2), float))
@@ -378,10 +378,11 @@ class TestCounterpartPairing:
         mem_chunk_num = 2
         source_pairing(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-            self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names,
-            self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings, self.amodelrefinds,
-            self.bmodelrefinds, self.rho, self.drho, self.n_fracs, mem_chunk_num,
-            group_sources_data=group_sources_data, phot_like_data=self.phot_like_data)
+            self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
+            self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
+            mem_chunk_num, group_sources_data=group_sources_data,
+            phot_like_data=self.phot_like_data, a_perturb_auf_outputs=self.a_perturb_auf_outputs,
+            b_perturb_auf_outputs=self.b_perturb_auf_outputs)
 
         bflux = np.load('{}/pairing/bcontamflux.npy'.format(self.joint_folder_path))
         assert np.all(bflux == np.zeros((2), float))
@@ -449,10 +450,12 @@ class TestCounterpartPairing:
         with pytest.warns(UserWarning) as record:
             source_pairing(
                 self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names,
-                self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings, self.amodelrefinds,
-                self.bmodelrefinds, self.rho, self.drho, self.n_fracs, mem_chunk_num,
-                group_sources_data=group_sources_data, phot_like_data=self.phot_like_data)
+                self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
+                self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
+                mem_chunk_num, group_sources_data=group_sources_data,
+                phot_like_data=self.phot_like_data,
+                a_perturb_auf_outputs=self.a_perturb_auf_outputs,
+                b_perturb_auf_outputs=self.b_perturb_auf_outputs)
         assert len(record) == 2
         assert '2 catalogue a sources not in either counterpart, f' in record[0].message.args[0]
         assert '1 catalogue b source not in either counterpart, f' in record[1].message.args[0]
@@ -500,10 +503,12 @@ class TestCounterpartPairing:
         with pytest.warns(UserWarning) as record:
             source_pairing(
                 self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                self.a_auf_folder_path, self.b_auf_folder_path, self.a_filt_names,
-                self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings, self.amodelrefinds,
-                self.bmodelrefinds, self.rho, self.drho, self.n_fracs, mem_chunk_num,
-                group_sources_data=group_sources_data, phot_like_data=self.phot_like_data)
+                self.a_filt_names, self.b_filt_names, self.a_auf_pointings, self.b_auf_pointings,
+                self.amodelrefinds, self.bmodelrefinds, self.rho, self.drho, self.n_fracs,
+                mem_chunk_num, group_sources_data=group_sources_data,
+                phot_like_data=self.phot_like_data,
+                a_perturb_auf_outputs=self.a_perturb_auf_outputs,
+                b_perturb_auf_outputs=self.b_perturb_auf_outputs)
         assert len(record) == 2
         assert '2 additional catalogue a indices recorded' in record[0].message.args[0]
         assert '1 additional catalogue b index recorded' in record[1].message.args[0]
@@ -565,6 +570,8 @@ class TestCounterpartPairing:
         self.cm.phot_like_data = self.phot_like_data
         self.files_per_pairing = 13
         self.cm.chunk_id = 1
+        self.cm.a_perturb_auf_outputs = self.a_perturb_auf_outputs
+        self.cm.b_perturb_auf_outputs = self.b_perturb_auf_outputs
         self.cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/chunk0/crossmatch_params_.txt'),
                                   os.path.join(os.path.dirname(__file__), 'data/chunk0/cat_a_params_.txt'),
                                   os.path.join(os.path.dirname(__file__), 'data/chunk0/cat_b_params_.txt'))

--- a/macauff/tests/test_counterpart_pairing.py
+++ b/macauff/tests/test_counterpart_pairing.py
@@ -567,14 +567,13 @@ class TestCounterpartPairing:
         self.cm.b_modelrefinds = self.bmodelrefinds
         self.cm.group_sources_data = self.group_sources_data
         self.cm.phot_like_data = self.phot_like_data
-        self.files_per_pairing = 13
         self.cm.chunk_id = 1
         self.cm.a_perturb_auf_outputs = self.a_perturb_auf_outputs
         self.cm.b_perturb_auf_outputs = self.b_perturb_auf_outputs
         self.cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/chunk0/crossmatch_params_.txt'),
                                   os.path.join(os.path.dirname(__file__), 'data/chunk0/cat_a_params_.txt'),
                                   os.path.join(os.path.dirname(__file__), 'data/chunk0/cat_b_params_.txt'))
-        self.cm.pair_sources(self.files_per_pairing)
+        self.cm.pair_sources()
 
         bflux = np.load('{}/pairing/bcontamflux.npy'.format(self.joint_folder_path))
         assert np.all(bflux == np.zeros((2), float))

--- a/macauff/tests/test_full_match_process.py
+++ b/macauff/tests/test_full_match_process.py
@@ -116,11 +116,8 @@ def generate_random_data(N_a, N_b, N_c, extent, n_a_filts, n_b_filts, a_astro_si
     np.save('{}/test_match_indices.npy'.format(b_cat), b_pair_indices)
 
 
-@pytest.mark.parametrize("use_memmap_files,x,y",
-                         [(True, 131, 0),
-                          (False, 131, 0),
-                          (False, 0, 0)])
-def test_naive_bayes_match(use_memmap_files, x, y):
+@pytest.mark.parametrize("x,y", [(131, 0), (0, 0)])
+def test_naive_bayes_match(x, y):
     # Generate a small number of sources randomly, then run through the
     # cross-match process.
     N_a, N_b, N_c = 40, 50, 35
@@ -138,7 +135,7 @@ def test_naive_bayes_match(use_memmap_files, x, y):
     # Ensure output chunk directory exists
     os.makedirs(os.path.join(os.path.dirname(__file__), "data/chunk0"), exist_ok=True)
 
-    ol, nl = 'run_auf = no', 'run_auf = yes\n'
+    ol, nl = 'pos_corr_dist = 11', 'pos_corr_dist = {:.2f}\n'.format(r)
     f = open(os.path.join(os.path.dirname(__file__),
                           'data/crossmatch_params.txt')).readlines()
     idx = np.where([ol in line for line in f])[0][0]
@@ -150,11 +147,9 @@ def test_naive_bayes_match(use_memmap_files, x, y):
 
     new_ext = [extent[0] - r/3600 - 0.1/3600, extent[1] + r/3600 + 0.1/3600,
                extent[2] - r/3600 - 0.1/3600, extent[3] + r/3600 + 0.1/3600]
-    for ol, nl in zip(['run_group = no', 'pos_corr_dist = 11',
-                       'cross_match_extent = 131 138 -3 3', 'joint_folder_path = test_path',
+    for ol, nl in zip(['cross_match_extent = 131 138 -3 3', 'joint_folder_path = test_path',
                        'cf_region_points = 131 134 4 -1 1 3'],
-                      ['run_group = yes\n', 'pos_corr_dist = {:.2f}\n'.format(r),
-                       'cross_match_extent = {:.3f} {:.3f} {:.3f} {:.3f}\n'.format(*new_ext),
+                      ['cross_match_extent = {:.3f} {:.3f} {:.3f} {:.3f}\n'.format(*new_ext),
                        'joint_folder_path = new_test_path\n',
                        'cf_region_points = {}\n'.format(new_region_points)]):
         f = open(os.path.join(os.path.dirname(__file__),
@@ -183,7 +178,7 @@ def test_naive_bayes_match(use_memmap_files, x, y):
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/chunk0/{}_.txt'.format(cat)),
                       idx, nl)
 
-    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files)
+    cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
     cm()
 
     ac = np.load('{}/pairing/ac.npy'.format(cm.joint_folder_path))

--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -3,6 +3,7 @@
 Tests for the "group_sources" module.
 '''
 
+import pytest
 import os
 from numpy.testing import assert_allclose
 import numpy as np
@@ -277,7 +278,7 @@ def test_clean_overlaps():
 
 class TestMakeIslandGroupings():
     def setup_class(self):
-        self.mem_chunk_num, self.include_phot_like, self.use_phot_prior = 2, False, False
+        self.include_phot_like, self.use_phot_prior = False, False
         self.max_sep, self.int_fracs = 11, [0.63, 0.9, 0.99]  # max_sep in arcseconds
         self.a_filt_names, self.b_filt_names = ['G', 'RP'], ['W1', 'W2', 'W3']
         self.a_title, self.b_title = 'gaia', 'wise'
@@ -372,7 +373,6 @@ class TestMakeIslandGroupings():
         self.cm.a_cat_folder_path = self.a_cat_folder_path
         self.cm.b_cat_folder_path = self.b_cat_folder_path
         self.cm.joint_folder_path = self.joint_folder_path
-        self.cm.mem_chunk_num = self.mem_chunk_num
         self.cm.include_phot_like = self.include_phot_like
         self.cm.use_phot_prior = self.use_phot_prior
         self.cm.j1s = self.j1s
@@ -452,6 +452,7 @@ class TestMakeIslandGroupings():
         self._comparisons_in_islands(alist, blist, agrplen, bgrplen, N_a, N_b, N_c)
         assert len(os.listdir('{}/reject'.format(self.joint_folder_path))) == 0
 
+    @pytest.mark.filterwarnings("ignore:.*island, containing.*")
     def test_mig_extra_reject(self):
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         self._fake_fourier_grid(self.N_a+10, self.N_b+11)
@@ -486,8 +487,8 @@ class TestMakeIslandGroupings():
             self.a_auf_pointings, self.b_auf_pointings, self.a_filt_names, self.b_filt_names,
             self.a_title, self.b_title, self.a_modelrefinds, self.b_modelrefinds, self.r, self.dr,
             self.rho, self.drho, self.j1s, self.max_sep, ax_lims, self.int_fracs,
-            self.mem_chunk_num, self.include_phot_like, self.use_phot_prior, self.n_pool,
-            self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)
+            self.include_phot_like, self.use_phot_prior, self.n_pool, self.a_perturb_auf_outputs,
+            self.b_perturb_auf_outputs)
 
         alist, blist = gsd.alist, gsd.blist
         agrplen, bgrplen = gsd.agrplen, gsd.bgrplen
@@ -520,6 +521,7 @@ class TestMakeIslandGroupings():
 
         assert len(os.listdir('{}/reject'.format(self.joint_folder_path))) == 2
 
+    @pytest.mark.filterwarnings("ignore:.*island, containing.*")
     def test_mig_no_reject_ax_lims(self):
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         self._fake_fourier_grid(self.N_a+10, self.N_b+11)
@@ -558,8 +560,8 @@ class TestMakeIslandGroupings():
             self.a_auf_pointings, self.b_auf_pointings, self.a_filt_names, self.b_filt_names,
             self.a_title, self.b_title, self.a_modelrefinds, self.b_modelrefinds, self.r, self.dr,
             self.rho, self.drho, self.j1s, self.max_sep, ax_lims, self.int_fracs,
-            self.mem_chunk_num, self.include_phot_like, self.use_phot_prior, self.n_pool,
-            self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)
+            self.include_phot_like, self.use_phot_prior, self.n_pool, self.a_perturb_auf_outputs,
+            self.b_perturb_auf_outputs)
 
         alist, blist = gsd.alist, gsd.blist
         agrplen, bgrplen = gsd.agrplen, gsd.bgrplen
@@ -584,8 +586,8 @@ class TestMakeIslandGroupings():
             self.a_auf_pointings, self.b_auf_pointings, self.a_filt_names, self.b_filt_names,
             self.a_title, self.b_title, self.a_modelrefinds, self.b_modelrefinds,  self.r, self.dr,
             self.rho, self.drho, self.j1s, self.max_sep, self.ax_lims, self.int_fracs,
-            self.mem_chunk_num, include_phot_like, self.use_phot_prior, self.n_pool,
-            self.a_perturb_auf_outputs, self.b_perturb_auf_outputs)
+            include_phot_like, self.use_phot_prior, self.n_pool, self.a_perturb_auf_outputs,
+            self.b_perturb_auf_outputs)
 
         # Verify that make_island_groupings doesn't change when the extra arrays
         # are calculated, as an initial test.

--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -325,8 +325,6 @@ class TestMakeIslandGroupings():
                 [self.a_auf_pointings, self.b_auf_pointings],
                 [self.a_filt_names, self.b_filt_names], [self.N_a, self.N_b]):
             np.save('{}/modelrefinds.npy'.format(auf_folder), np.zeros((3, N), int))
-            np.save('{}/arraylengths.npy'.format(auf_folder),
-                    np.ones((len(filters), len(auf_points)), int))
             if 'gaia' in auf_folder:
                 self.a_modelrefinds = np.zeros((3, N), int)
             else:

--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -251,12 +251,8 @@ class TestOverlap():
 
 
 def test_clean_overlaps():
-    joint_folder_path, filename = '.', 'list'
-    os.makedirs('group', exist_ok=True)
     maxsize, size = 5, np.array([3, 5, 3, 4, 4, 5, 4, 2, 5, 4]*3)
-    inds = np.lib.format.open_memmap('{}/group/{}.npy'.format(joint_folder_path, filename),
-                                     mode='w+', dtype=int, shape=(maxsize, len(size)),
-                                     fortran_order=True)
+    inds = np.empty(dtype=int, shape=(maxsize, len(size)), order='F')
     for i in range(0, 3):
         inds[:, 0+10*i] = [0, 1, 0, -1, -1]
         inds[:, 1+10*i] = [3, 4, 1, 1, 4]
@@ -269,7 +265,7 @@ def test_clean_overlaps():
         inds[:, 8+10*i] = [2, 2, 2, 2, 2]
         inds[:, 9+10*i] = [1, 1, 2, 3, -1]
 
-    inds2, size2 = _clean_overlaps(inds, size, joint_folder_path, filename, 2)
+    inds2, size2 = _clean_overlaps(inds, size, 2)
     compare_inds2 = np.empty((4, 30), int)
     for i in range(0, 3):
         compare_inds2[:, 0+10*i] = [0, 1, -1, -1]
@@ -298,8 +294,7 @@ class TestMakeIslandGroupings():
         for folder in [self.a_cat_folder_path, self.b_cat_folder_path, self.joint_folder_path,
                        self.a_auf_folder_path, self.b_auf_folder_path]:
             os.makedirs(folder, exist_ok=True)
-        for folder in ['group', 'reject']:
-            os.makedirs('{}/{}'.format(self.joint_folder_path, folder), exist_ok=True)
+        os.makedirs('{}/reject'.format(self.joint_folder_path), exist_ok=True)
         self.r = np.linspace(0, self.max_sep, 10000)
         self.dr = np.diff(self.r)
         self.rho = np.linspace(0, 100, 9900)
@@ -446,7 +441,6 @@ class TestMakeIslandGroupings():
                                                    *np.arange(N_c, N_b), 0]))).reshape(1, -1)
 
     def test_make_island_groupings(self):
-        os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         N_a, N_b, N_c = self.N_a, self.N_b, self.N_com
         np.save('{}/con_cat_astro.npy'.format(self.a_cat_folder_path), self.a_coords)
@@ -464,7 +458,6 @@ class TestMakeIslandGroupings():
         assert len(os.listdir('{}/reject'.format(self.joint_folder_path))) == 0
 
     def test_mig_extra_reject(self):
-        os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         N_a, N_b, N_c = self.N_a, self.N_b, self.N_com
         ax_lims = self.ax_lims
@@ -521,7 +514,6 @@ class TestMakeIslandGroupings():
         assert len(os.listdir('{}/reject'.format(self.joint_folder_path))) == 2
 
     def test_mig_no_reject_ax_lims(self):
-        os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         N_a, N_b, N_c = self.N_a, self.N_b, self.N_com
         ax_lims = np.array([0, 360, -90, -88])
@@ -562,7 +554,6 @@ class TestMakeIslandGroupings():
         assert len(os.listdir('{}/reject'.format(self.joint_folder_path))) == 2
 
     def test_make_island_groupings_include_phot_like(self):
-        os.system('rm -rf {}/group/*'.format(self.joint_folder_path))
         os.system('rm -rf {}/reject/*'.format(self.joint_folder_path))
         np.save('{}/con_cat_astro.npy'.format(self.a_cat_folder_path), self.a_coords)
         np.save('{}/con_cat_astro.npy'.format(self.b_cat_folder_path), self.b_coords)

--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -11,7 +11,7 @@ from scipy.special import j1
 from ..matching import CrossMatch
 from ..group_sources import make_island_groupings, _load_fourier_grid_cutouts, _clean_overlaps
 from ..group_sources_fortran import group_sources_fortran as gsf
-from ..misc_functions import _create_rectangular_slice_arrays, create_auf_params_grid
+from ..misc_functions import create_auf_params_grid
 from .test_matching import _replace_line
 
 
@@ -50,15 +50,9 @@ def test_load_fourier_grid_cutouts():
     rect = np.array([40, 60, 40, 60])
 
     padding = 0.1
-    _create_rectangular_slice_arrays('.', 'check', len(a))
-    memmap_arrays = []
-    for n in ['1', '2', '3', '4', 'combined']:
-        memmap_arrays.append(np.lib.format.open_memmap('{}/{}_temporary_sky_slice_{}.npy'.format(
-                             '.', 'check', n), mode='r+', dtype=bool, shape=(len(a),)))
     p_a_o = {'fourier_grid': grid}
     _a, _b, _c, _ = _load_fourier_grid_cutouts(a, rect, '.', '.', p_a_o, padding, 'check',
-                                               memmap_arrays, np.array([True]*lena),
-                                               modelrefinds=m)
+                                               np.array([True]*lena), modelrefinds=m)
     assert np.all(_a.shape == (4, 3))
     assert np.all(_a ==
                   np.array([[50, 50, 0.1], [48, 60.02, 0.5], [39.98, 43, 0.2], [45, 45, 0.2]]))
@@ -81,8 +75,7 @@ def test_load_fourier_grid_cutouts():
     # reference index. Hence we only have one unique grid reference now.
     padding = 0
     _a, _b, _c, _ = _load_fourier_grid_cutouts(a, rect, '.', '.', p_a_o, padding, 'check',
-                                               memmap_arrays, np.array([True]*lena),
-                                               modelrefinds=m)
+                                               np.array([True]*lena), modelrefinds=m)
     assert np.all(_a.shape == (2, 3))
     assert np.all(_a == np.array([[50, 50, 0.1], [45, 45, 0.2]]))
     assert np.all(_b.shape == (100, 1, 1, 1))

--- a/macauff/tests/test_group_sources.py
+++ b/macauff/tests/test_group_sources.py
@@ -3,7 +3,6 @@
 Tests for the "group_sources" module.
 '''
 
-import pytest
 import os
 from numpy.testing import assert_allclose
 import numpy as np

--- a/macauff/tests/test_make_set_list.py
+++ b/macauff/tests/test_make_set_list.py
@@ -35,7 +35,6 @@ def test_initial_group_numbering():
 
 def test_set_list_maximum_exceeded():
     os.makedirs('./group', exist_ok=True)
-    os.makedirs('./reject', exist_ok=True)
     for i, (N_a, N_b) in enumerate(zip([21, 10, 7], [5, 10, 6])):
         a_overlaps = np.empty((N_b, N_a+2), int)
         a_overlaps[:, :-2] = np.arange(N_b).reshape(-1, 1)
@@ -52,7 +51,7 @@ def test_set_list_maximum_exceeded():
         if i != 2:
             with pytest.warns(UserWarning, match='1 island, containing {}/{} catalogue a and '
                               '{}/{} catalogue b stars'.format(N_a, N_a+2, N_b, N_b+2)):
-                alist, blist, agrplen, bgrplen = set_list(
+                alist, blist, agrplen, bgrplen, areject, breject = set_list(
                     a_overlaps, b_overlaps, a_num, b_num, '.', 2)
         else:
             with pytest.warns(None) as record:

--- a/macauff/tests/test_make_set_list.py
+++ b/macauff/tests/test_make_set_list.py
@@ -25,8 +25,7 @@ def test_initial_group_numbering():
                                [11], [12, 19], [13], [14], [], [], [12], [3]]):
         b_overlaps[:len(_inds), _i] = np.array(_inds)
     os.makedirs('./group', exist_ok=True)
-    agroup, bgroup = _initial_group_numbering(a_overlaps, b_overlaps, a_num, b_num, '.',
-                                              use_memmap_files=True)
+    agroup, bgroup = _initial_group_numbering(a_overlaps, b_overlaps, a_num, b_num, '.')
 
     assert np.all(agroup == np.array(
         [18, 1, 2, 19, 3, 4, 5, 6, 7, 8, 9, 10, 20, 11, 12, 13, 14, 15, 18, 20]))
@@ -54,11 +53,11 @@ def test_set_list_maximum_exceeded():
             with pytest.warns(UserWarning, match='1 island, containing {}/{} catalogue a and '
                               '{}/{} catalogue b stars'.format(N_a, N_a+2, N_b, N_b+2)):
                 alist, blist, agrplen, bgrplen = set_list(
-                    a_overlaps, b_overlaps, a_num, b_num, '.', 2, use_memmap_files=True)
+                    a_overlaps, b_overlaps, a_num, b_num, '.', 2)
         else:
             with pytest.warns(None) as record:
                 alist, blist, agrplen, bgrplen = set_list(
-                    a_overlaps, b_overlaps, a_num, b_num, '.', 2, use_memmap_files=True)
+                    a_overlaps, b_overlaps, a_num, b_num, '.', 2)
             # Should be empty if no warnings were raised.
             assert not record
         if i != 2:

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -74,7 +74,7 @@ class TestInputs:
         np.save('b_snr_mag/snr_mag_params.npy', np.ones((4, 3, 5), float))
 
     def test_crossmatch_run_input(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         with pytest.raises(FileNotFoundError):
             cm._initialise_chunk('./file.txt', './file2.txt', './file3.txt')
         with pytest.raises(FileNotFoundError):
@@ -86,36 +86,8 @@ class TestInputs:
                                  os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                                  './file3.txt')
 
-        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert cm.run_auf is False
-        assert cm.run_group is False
-        assert cm.run_cf is True
-        assert cm.run_source is True
-
-        # List of simple one line config file replacements for error message checking
-        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
-        for old_line, new_line, match_text in zip(['run_cf = yes', 'run_auf = no', 'run_auf = no'],
-                                                  ['', 'run_auf = aye\n', 'run_auf = yes\n'],
-                                                  ['Missing key', 'Boolean flag key not set',
-                                                   'Inconsistency between run/no run']):
-            idx = np.where([old_line in line for line in f])[0][0]
-            _replace_line(os.path.join(os.path.dirname(__file__),
-                          'data/crossmatch_params.txt'), idx, new_line,
-                          out_file=os.path.join(os.path.dirname(__file__),
-                          'data/crossmatch_params_.txt'))
-
-            with pytest.raises(ValueError, match=match_text):
-                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
-                                     'data/crossmatch_params_.txt'),
-                                     os.path.join(os.path.dirname(__file__),
-                                     'data/cat_a_params.txt'),
-                                     os.path.join(os.path.dirname(__file__),
-                                     'data/cat_b_params.txt'))
-
     def test_crossmatch_auf_cf_input(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -298,7 +270,7 @@ class TestInputs:
                                       [131, 1], [132, 1], [133, 1], [134, 1]]))
 
     def test_crossmatch_folder_path_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -337,7 +309,7 @@ class TestInputs:
                                                   .format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_tri_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -362,24 +334,23 @@ class TestInputs:
         # List of simple one line config file replacements for error message checking
         for old_line, new_line, match_text, in_file in zip(
                 ['tri_set_name = gaiaDR2', 'tri_filt_num = 11', 'tri_filt_num = 11',
-                 'download_tri = no', 'download_tri = no', 'tri_maglim_faint = 32',
+                 'download_tri = no', 'tri_maglim_faint = 32',
                  'tri_maglim_faint = 32', 'tri_num_faint = 1500000', 'tri_num_faint = 1500000',
                  'tri_num_faint = 1500000'],
                 ['', 'tri_filt_num = a\n', 'tri_filt_num = 3.4\n', 'download_tri = aye\n',
-                 'download_tri = yes\n', 'tri_maglim_faint = 32 33.5\n',
-                 'tri_maglim_faint = a\n', 'tri_num_faint = 1500000.1\n', 'tri_num_faint = a\n',
+                 'tri_maglim_faint = 32 33.5\n', 'tri_maglim_faint = a\n',
+                 'tri_num_faint = 1500000.1\n', 'tri_num_faint = a\n',
                  'tri_num_faint = 1500000 15\n'],
                 ['Missing key tri_set_name from catalogue "a"',
                  'tri_filt_num should be a single integer number in catalogue "b"',
                  'tri_filt_num should be a single integer number in catalogue "b"',
-                 'Boolean flag key not set', 'a_download_tri is True and run_auf is False',
-                 'tri_maglim_faint in catalogue "a" must be a float.',
+                 'Boolean flag key not set', 'tri_maglim_faint in catalogue "a" must be a float.',
                  'tri_maglim_faint in catalogue "b" must be a float.',
                  'tri_num_faint should be a single integer number in catalogue "b"',
                  'tri_num_faint should be a single integer number in catalogue "a" metadata file',
                  'tri_num_faint should be a single integer number in catalogue "a"'],
                 ['cat_a_params', 'cat_b_params', 'cat_b_params', 'cat_a_params', 'cat_a_params',
-                 'cat_a_params', 'cat_b_params', 'cat_b_params', 'cat_a_params', 'cat_a_params']):
+                 'cat_b_params', 'cat_b_params', 'cat_a_params', 'cat_a_params']):
             f = open(os.path.join(os.path.dirname(__file__),
                                   'data/{}.txt'.format(in_file))).readlines()
             idx = np.where([old_line in line for line in f])[0][0]
@@ -398,7 +369,7 @@ class TestInputs:
                                                   .format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_psf_param_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -457,7 +428,7 @@ class TestInputs:
                 np.save('a_snr_mag/snr_mag_params.npy', np.ones((3, 1, 5), float))
 
     def test_crossmatch_cat_name_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -480,7 +451,7 @@ class TestInputs:
                                  os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
 
     def test_crossmatch_search_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -549,7 +520,7 @@ class TestInputs:
                       'data/crossmatch_params.txt'), idx, new_line, out_file=os.path.join(
                       os.path.dirname(__file__), 'data/crossmatch_params_.txt'))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -614,7 +585,7 @@ class TestInputs:
         np.save('a_snr_mag/snr_mag_params.npy', np.ones((3, 1, 5), float))
         np.save('b_snr_mag/snr_mag_params.npy', np.ones((4, 1, 5), float))
 
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                              'data/crossmatch_params_.txt'),
                              os.path.join(os.path.dirname(__file__),
@@ -824,7 +795,7 @@ class TestInputs:
                                                   .format('_' if '_a_' in file else '__')))
 
     def test_crossmatch_fourier_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -854,7 +825,7 @@ class TestInputs:
                                      'data/cat_b_params.txt'))
 
     def test_crossmatch_frame_equality(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -889,7 +860,7 @@ class TestInputs:
                                                   .format('_' if '_b_' in in_file else '')))
 
     def test_cross_match_extent(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -922,7 +893,7 @@ class TestInputs:
                                                   .format('_' if '_b_' in in_file else '')))
 
     def test_int_fracs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -954,7 +925,7 @@ class TestInputs:
                                                   .format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_chunk_num(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -986,7 +957,7 @@ class TestInputs:
                                                   .format('_' if '_b_' in in_file else '')))
 
     def test_crossmatch_shared_data(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -996,7 +967,7 @@ class TestInputs:
         assert_allclose(cm.drho, np.ones(9999, float) * 100/9999)
 
     def test_cat_folder_path(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -1065,7 +1036,7 @@ class TestInputs:
             self.setup_class()
 
     def test_calculate_cf_areas(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -1086,7 +1057,7 @@ class TestInputs:
         assert_allclose(cm.cf_areas, calculated_areas, rtol=0.025)
 
     def test_csv_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         f = open(os.path.join(os.path.dirname(__file__),
                               'data/crossmatch_params.txt')).readlines()
         old_line = 'make_output_csv = no'
@@ -1315,7 +1286,7 @@ class TestInputs:
 
     @pytest.mark.remote_data
     def test_crossmatch_correct_astrometry_inputs(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
@@ -1565,7 +1536,7 @@ class TestInputs:
             os.remove('ac_folder/npy/snr_mag_params.npy')
         # Using the ORIGINAL cat_a_params means we don't fit for corrections
         # to catalogue 'a'.
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm.chunk_id = 1
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                              'data/crossmatch_params.txt'),
@@ -1601,7 +1572,7 @@ class TestInputs:
         if os.path.isfile('ac_folder/npy/snr_mag_params.npy'):
             os.remove('ac_folder/npy/snr_mag_params.npy')
         # Swapped a+b to test a_* versions of things
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm.chunk_id = 1
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                              'data/crossmatch_params.txt'),
@@ -1651,7 +1622,7 @@ class TestInputs:
                                                 'data/cat_{}_params_2b.txt'.format(x)))
         if os.path.isfile('ac_folder/npy/snr_mag_params.npy'):
             os.remove('ac_folder/npy/snr_mag_params.npy')
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm.chunk_id = 1
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                              'data/crossmatch_params.txt'),
@@ -1671,7 +1642,7 @@ class TestInputs:
         assert_allclose([marray[0], narray[0]], [2, 0], rtol=0.1, atol=0.01)
         if os.path.isfile('ac_folder/npy/snr_mag_params.npy'):
             os.remove('ac_folder/npy/snr_mag_params.npy')
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'), use_memmap_files=True)
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm.chunk_id = 1
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                              'data/crossmatch_params.txt'),
@@ -1804,7 +1775,6 @@ class TestInputs:
                                               .format('_2' if x == 'a' else '_3')))
 
 
-@pytest.mark.parametrize('use_memmap', [True, False])
 class TestPostProcess:
     def setup_method(self):
         self.joint_folder_path = os.path.abspath('joint')
@@ -1880,9 +1850,8 @@ class TestPostProcess:
         data1[:, 0] = ['{}{}'.format(designation, i) for i in data1[:, 0]]
         return data, data1
 
-    def test_postprocess(self, use_memmap):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'),
-                        use_memmap_files=use_memmap)
+    def test_postprocess(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm.joint_folder_path = self.joint_folder_path
         cm.a_cat_folder_path = self.a_cat_folder_path
         cm.b_cat_folder_path = self.b_cat_folder_path
@@ -1913,9 +1882,8 @@ class TestPostProcess:
         assert np.all(aino[deleted_af])
         assert np.all(bino[deleted_bf])
 
-    def test_postprocess_with_csv(self, use_memmap):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'),
-                        use_memmap_files=use_memmap)
+    def test_postprocess_with_csv(self):
+        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm.joint_folder_path = self.joint_folder_path
         cm.a_cat_folder_path = self.a_cat_folder_path
         cm.b_cat_folder_path = self.b_cat_folder_path

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -468,20 +468,6 @@ class TestInputs:
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert np.all(cm.a_psf_fwhms == np.array([0.12, 0.12, 0.12]))
-        assert not hasattr(cm, 'b_dens_dist')
-
-        f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
-        old_line = 'compute_local_density = no'
-        new_line = 'compute_local_density = yes\n'
-        idx = np.where([old_line in line for line in f])[0][0]
-        _replace_line(os.path.join(os.path.dirname(__file__),
-                      'data/crossmatch_params_.txt'), idx, new_line, out_file=os.path.join(
-                      os.path.dirname(__file__), 'data/crossmatch_params_2.txt'))
-        cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
-                                          'data/crossmatch_params_2.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert np.all(cm.a_psf_fwhms == np.array([0.12, 0.12, 0.12]))
         assert cm.b_dens_dist == 0.25
 
         # List of simple one line config file replacements for error message checking
@@ -496,14 +482,13 @@ class TestInputs:
                                   'data/{}.txt'.format(in_file))).readlines()
             idx = np.where([old_line in line for line in f])[0][0]
             _replace_line(os.path.join(os.path.dirname(__file__),
-                          'data/{}{}.txt'.format(in_file, '_2' if 'h_p' in in_file else '')), idx,
+                          'data/{}{}.txt'.format(in_file, '_' if 'h_p' in in_file else '')), idx,
                           new_line, out_file=os.path.join(os.path.dirname(__file__),
-                          'data/{}_{}.txt'.format(in_file, '3' if 'h_p' in in_file else '')))
-
+                          'data/{}_{}.txt'.format(in_file, '2' if 'h_p' in in_file else '')))
             with pytest.raises(ValueError, match=match_text):
                 cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
                                      'data/crossmatch_params{}.txt'.format(
-                                     '_3' if 'h_p' in in_file else '_2')),
+                                     '_2' if 'h_p' in in_file else '_')),
                                      os.path.join(os.path.dirname(__file__),
                                      'data/cat_a_params{}.txt'
                                                   .format('_' if '_a_' in in_file else '')),
@@ -525,19 +510,15 @@ class TestInputs:
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.num_trials == 10000
-        assert not cm.compute_local_density
         assert cm.d_mag == 0.1
 
         for old_line, new_line, match_text in zip(
                 ['num_trials = 10000', 'num_trials = 10000', 'num_trials = 10000',
-                 'd_mag = 0.1', 'd_mag = 0.1', 'compute_local_density = no',
-                 'compute_local_density = no', 'compute_local_density = no'],
-                ['', 'num_trials = word\n', 'num_trials = 10000.1\n', '', 'd_mag = word\n', '',
-                 'compute_local_density = word\n', 'compute_local_density = 10\n'],
+                 'd_mag = 0.1', 'd_mag = 0.1'],
+                ['', 'num_trials = word\n', 'num_trials = 10000.1\n', '', 'd_mag = word\n'],
                 ['Missing key num_trials from joint', 'num_trials should be an integer',
                  'num_trials should be an integer', 'Missing key d_mag from joint',
-                 'd_mag must be a float', 'Missing key compute_local_density from joint',
-                 'Boolean flag key not set to allowed', 'Boolean flag key not set to allowed']):
+                 'd_mag must be a float']):
             # Make sure to keep the first edit of crossmatch_params, adding each
             # second change in turn.
             f = open(os.path.join(os.path.dirname(__file__),

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -904,38 +904,6 @@ class TestInputs:
                                      'data/cat_b_params{}.txt'
                                                   .format('_' if '_b_' in in_file else '')))
 
-    def test_crossmatch_chunk_num(self):
-        cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
-        cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
-                             os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
-        assert np.all(cm.mem_chunk_num == 10)
-
-        # List of simple one line config file replacements for error message checking
-        in_file = 'crossmatch_params'
-        f = open(os.path.join(os.path.dirname(__file__),
-                              'data/{}.txt'.format(in_file))).readlines()
-        old_line = 'mem_chunk_num = 10'
-        for new_line, match_text in zip(
-                ['', 'mem_chunk_num = word\n', 'mem_chunk_num = 10.1\n'],
-                ['Missing key mem_chunk_num', 'mem_chunk_num should be a single integer',
-                 'mem_chunk_num should be a single integer']):
-            idx = np.where([old_line in line for line in f])[0][0]
-            _replace_line(os.path.join(os.path.dirname(__file__),
-                          'data/{}.txt'.format(in_file)), idx, new_line, out_file=os.path.join(
-                          os.path.dirname(__file__), 'data/{}_.txt'.format(in_file)))
-
-            with pytest.raises(ValueError, match=match_text):
-                cm._initialise_chunk(os.path.join(os.path.dirname(__file__),
-                                     'data/crossmatch_params{}.txt'.format(
-                                     '_' if 'h_p' in in_file else '')),
-                                     os.path.join(os.path.dirname(__file__),
-                                     'data/cat_a_params{}.txt'
-                                                  .format('_' if '_a_' in in_file else '')),
-                                     os.path.join(os.path.dirname(__file__),
-                                     'data/cat_b_params{}.txt'
-                                                  .format('_' if '_b_' in in_file else '')))
-
     def test_crossmatch_shared_data(self):
         cm = CrossMatch(os.path.join(os.path.dirname(__file__), 'data'))
         cm._initialise_chunk(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
@@ -1901,7 +1869,6 @@ class TestPostProcess:
         cm.b_cat_col_nums = [0, 1, 2, 4, 5, 6, 7]
         cm.a_cat_name = 'Gaia'
         cm.b_cat_name = 'WISE'
-        cm.mem_chunk_num = 4
         cm.a_input_npy_folder = None
         cm.b_input_npy_folder = None
         cm.a_extra_col_names = None

--- a/macauff/tests/test_matching.py
+++ b/macauff/tests/test_matching.py
@@ -433,7 +433,6 @@ class TestInputs:
                              os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt'),
                              os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         assert cm.b_cat_name == 'WISE'
-        assert os.path.exists('{}/test_path/WISE'.format(os.getcwd()))
 
         f = open(os.path.join(os.path.dirname(__file__), 'data/cat_a_params.txt')).readlines()
         old_line = 'cat_name = Gaia'

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -97,7 +97,7 @@ def test_hav_dist_constant_lat():
 
 def test_large_small_index():
     inds = np.array([0, 10, 15, 10, 35])
-    a, b = map_large_index_to_small_index(inds, 40, '.')
+    a, b = map_large_index_to_small_index(inds, 40)
     assert np.all(a == np.array([0, 1, 2, 1, 3]))
     assert np.all(b == np.array([0, 10, 15, 35]))
 

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -3,7 +3,6 @@
 Tests for the "misc_functions" module.
 '''
 
-import os
 import numpy as np
 from numpy.testing import assert_allclose
 import scipy.special

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -9,8 +9,7 @@ import scipy.special
 
 from ..misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
                               hav_dist_constant_lat, map_large_index_to_small_index,
-                              _load_rectangular_slice, _load_single_sky_slice,
-                              _create_rectangular_slice_arrays, min_max_lon)
+                              _load_rectangular_slice, _load_single_sky_slice, min_max_lon)
 from ..misc_functions_fortran import misc_functions_fortran as mff
 
 
@@ -109,13 +108,7 @@ def test_load_rectangular_slice():
         if x < 0:
             a[a[:, 0] < 0, 0] = a[a[:, 0] < 0, 0] + 360
         lon1, lon2, lat1, lat2 = x+0.2, x+0.4, x+0.1, x+0.3
-        _create_rectangular_slice_arrays('.', '', len(a))
-        memmap_arrays = []
-        for n in ['1', '2', '3', '4', 'combined']:
-            memmap_arrays.append(np.lib.format.open_memmap('{}/{}_temporary_sky_slice_{}.npy'
-                                 .format('.', '', n), mode='r+', dtype=bool, shape=(len(a),)))
-        sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2,
-                                          padding, memmap_arrays)
+        sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2, padding)
         for i in range(len(a)):
             within_range = np.empty(4, bool)
             if x > 0:

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -9,7 +9,7 @@ import scipy.special
 
 from ..misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
                               hav_dist_constant_lat, map_large_index_to_small_index,
-                              _load_rectangular_slice, _load_single_sky_slice, min_max_lon)
+                              _load_rectangular_slice, min_max_lon)
 from ..misc_functions_fortran import misc_functions_fortran as mff
 
 
@@ -155,13 +155,3 @@ def test_min_max_lon():
             min_n, max_n = min_lon - 360, max_lon
         new_min_lon, new_max_lon = min_max_lon(a)
         assert_allclose([new_min_lon, new_max_lon], [min_n, max_n], rtol=0.01)
-
-
-def test_load_single_sky_slice():
-    cat_name = ''
-    ind = 3
-
-    rng = np.random.default_rng(6123123)
-    sky_inds = rng.choice(5, size=5000)
-    sky_cut = _load_single_sky_slice(cat_name, ind, sky_inds)
-    assert np.all(sky_cut == (sky_inds == ind))

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -8,8 +8,7 @@ from numpy.testing import assert_allclose
 import scipy.special
 
 from ..misc_functions import (create_auf_params_grid, load_small_ref_auf_grid,
-                              hav_dist_constant_lat, map_large_index_to_small_index,
-                              _load_rectangular_slice, min_max_lon)
+                              hav_dist_constant_lat, _load_rectangular_slice, min_max_lon)
 from ..misc_functions_fortran import misc_functions_fortran as mff
 
 
@@ -92,13 +91,6 @@ def test_hav_dist_constant_lat():
             a = mff.haversine_wrapper(lon1, lon2, lat, lat)
             b = hav_dist_constant_lat(lon1, lat, lon2)
             assert_allclose(a, b)
-
-
-def test_large_small_index():
-    inds = np.array([0, 10, 15, 10, 35])
-    a, b = map_large_index_to_small_index(inds, 40)
-    assert np.all(a == np.array([0, 1, 2, 1, 3]))
-    assert np.all(b == np.array([0, 10, 15, 35]))
 
 
 def test_load_rectangular_slice():

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -108,7 +108,7 @@ def test_load_rectangular_slice():
         if x < 0:
             a[a[:, 0] < 0, 0] = a[a[:, 0] < 0, 0] + 360
         lon1, lon2, lat1, lat2 = x+0.2, x+0.4, x+0.1, x+0.3
-        sky_cut = _load_rectangular_slice('.', '', a, lon1, lon2, lat1, lat2, padding)
+        sky_cut = _load_rectangular_slice('', a, lon1, lon2, lat1, lat2, padding)
         for i in range(len(a)):
             within_range = np.empty(4, bool)
             if x > 0:
@@ -158,11 +158,10 @@ def test_min_max_lon():
 
 
 def test_load_single_sky_slice():
-    folder_path = '.'
     cat_name = ''
     ind = 3
 
     rng = np.random.default_rng(6123123)
     sky_inds = rng.choice(5, size=5000)
-    sky_cut = _load_single_sky_slice(folder_path, cat_name, ind, sky_inds)
+    sky_cut = _load_single_sky_slice(cat_name, ind, sky_inds)
     assert np.all(sky_cut == (sky_inds == ind))

--- a/macauff/tests/test_misc_functions.py
+++ b/macauff/tests/test_misc_functions.py
@@ -45,8 +45,8 @@ def test_create_fourier_offsets_grid():
             np.save('{}/{}/{}/fourier.npy'.format(ax1, ax2, filt),
                     (i + len(filt_names)*j)*np.ones((len(r[:-1]), a_len[i, j]), float))
 
-    create_auf_params_grid('.', auf_pointings, filt_names, 'fourier',
-                           use_memmap_files=True, len_first_axis=len(r)-1)
+    create_auf_params_grid('.', auf_pointings, filt_names, 'fourier', a_len,
+                           len_first_axis=len(r)-1)
     a = np.lib.format.open_memmap('{}/fourier_grid.npy'.format(
         '.'), mode='r', dtype=float, shape=(9, 15, 2, 3), fortran_order=True)
     assert np.all(a.shape == (9, 15, 2, 3))
@@ -100,7 +100,7 @@ def test_hav_dist_constant_lat():
 
 def test_large_small_index():
     inds = np.array([0, 10, 15, 10, 35])
-    a, b = map_large_index_to_small_index(inds, 40, '.', use_memmap_files=True)
+    a, b = map_large_index_to_small_index(inds, 40, '.')
     assert np.all(a == np.array([0, 1, 2, 1, 3]))
     assert np.all(b == np.array([0, 10, 15, 35]))
 
@@ -174,5 +174,5 @@ def test_load_single_sky_slice():
 
     rng = np.random.default_rng(6123123)
     sky_inds = rng.choice(5, size=5000)
-    sky_cut = _load_single_sky_slice(folder_path, cat_name, ind, sky_inds, use_memmap_files=True)
+    sky_cut = _load_single_sky_slice(folder_path, cat_name, ind, sky_inds)
     assert np.all(sky_cut == (sky_inds == ind))

--- a/macauff/tests/test_parse_catalogue.py
+++ b/macauff/tests/test_parse_catalogue.py
@@ -323,8 +323,8 @@ class TestParseCatalogueNpyToCsv:
 
         npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data.csv', 'test_b_data.csv'],
                    ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'], [a_cols, b_cols],
-                   [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], 20,
-                   headers=[False, False], input_npy_folders=[None, None])
+                   [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], headers=[False, False],
+                   input_npy_folders=[None, None])
 
         assert os.path.isfile('match_csv.csv')
         assert os.path.isfile('a_nonmatch_csv.csv')
@@ -385,8 +385,8 @@ class TestParseCatalogueNpyToCsv:
 
         npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data.csv', 'test_b_data.csv'],
                    ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'], [a_cols, b_cols],
-                   [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], 20,
-                   headers=[False, False], input_npy_folders=['test_a_out', 'test_b_out'])
+                   [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], headers=[False, False],
+                   input_npy_folders=['test_a_out', 'test_b_out'])
 
         assert os.path.isfile('match_csv.csv')
         assert os.path.isfile('a_nonmatch_csv.csv')
@@ -436,8 +436,8 @@ class TestParseCatalogueNpyToCsv:
 
         npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data.csv', 'test_b_data.csv'],
                    ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'], [a_cols, b_cols],
-                   [[1, 2, 0, 4, 5], [4, 5, 6, 0, 1, 2]], ['A', 'B'], 20,
-                   headers=[False, False], input_npy_folders=[None, None])
+                   [[1, 2, 0, 4, 5], [4, 5, 6, 0, 1, 2]], ['A', 'B'], headers=[False, False],
+                   input_npy_folders=[None, None])
 
         assert os.path.isfile('match_csv.csv')
         assert os.path.isfile('a_nonmatch_csv.csv')
@@ -491,7 +491,7 @@ class TestParseCatalogueNpyToCsv:
         with pytest.raises(UserWarning, match="either both need to be None, or both"):
             npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data.csv', 'test_b_data.csv'],
                        ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'],
-                       [a_cols, b_cols], [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], 20,
+                       [a_cols, b_cols], [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'],
                        headers=[False, False], extra_col_name_lists=[[1], [2]],
                        input_npy_folders=[None, None])
 
@@ -507,12 +507,10 @@ class TestParseCatalogueNpyToCsv:
         add_b_nums = [3]
 
         npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data.csv', 'test_b_data.csv'],
-                               ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'],
-                               [a_cols, b_cols], [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'],
-                               20, headers=[False, False],
-                               extra_col_name_lists=[add_a_cols, add_b_cols],
-                               extra_col_num_lists=[add_a_nums, add_b_nums],
-                               input_npy_folders=[None, None])
+                   ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'], [a_cols, b_cols],
+                   [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], headers=[False, False],
+                   extra_col_name_lists=[add_a_cols, add_b_cols],
+                   extra_col_num_lists=[add_a_nums, add_b_nums], input_npy_folders=[None, None])
 
         assert os.path.isfile('match_csv.csv')
         assert os.path.isfile('a_nonmatch_csv.csv')
@@ -582,12 +580,10 @@ class TestParseCatalogueNpyToCsv:
         add_b_nums = []
 
         npy_to_csv(['.', '.'], 'test_folder', '.', ['test_a_data.csv', 'test_b_data.csv'],
-                               ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'],
-                               [a_cols, b_cols], [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'],
-                               20, headers=[False, False],
-                               extra_col_name_lists=[add_a_cols, add_b_cols],
-                               extra_col_num_lists=[add_a_nums, add_b_nums],
-                               input_npy_folders=[None, None])
+                   ['match_csv.csv', 'a_nonmatch_csv.csv', 'b_nonmatch_csv.csv'], [a_cols, b_cols],
+                   [[0, 1, 2, 4, 5], [0, 1, 2, 4, 5, 6]], ['A', 'B'], headers=[False, False],
+                   extra_col_name_lists=[add_a_cols, add_b_cols],
+                   extra_col_num_lists=[add_a_nums, add_b_nums], input_npy_folders=[None, None])
 
         assert os.path.isfile('match_csv.csv')
         assert os.path.isfile('a_nonmatch_csv.csv')

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -37,7 +37,6 @@ class TestCreatePerturbAUF:
         self.cm.a_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
         self.cm.b_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
         self.cm.mem_chunk_num = 4
-        self.files_per_auf_sim = 7
 
     def test_no_perturb_outputs(self):
         # Randomly generate two catalogues (x3 files) between coordinates
@@ -60,7 +59,7 @@ class TestCreatePerturbAUF:
 
         self.cm.include_perturb_auf = False
         self.cm.chunk_id = 1
-        self.cm.create_perturb_auf(self.files_per_auf_sim)
+        self.cm.create_perturb_auf()
         p_a_o = self.cm.b_perturb_auf_outputs
         lenr = len(self.cm.r)
         lenrho = len(self.cm.rho)
@@ -906,7 +905,7 @@ class TestMakePerturbAUFs():
 
         cm.chunk_id = 1
 
-        cm.create_perturb_auf(self.files_per_auf_sim)
+        cm.create_perturb_auf()
 
         perturb_auf_combo = '{}-{}-{}'.format(ax1, ax2, self.filters[0])
         fracs = cm.b_perturb_auf_outputs[perturb_auf_combo]['frac']
@@ -1087,7 +1086,7 @@ class TestMakePerturbAUFs():
         cm.a_dens_dist = density_radius
         cm.b_dens_dist = density_radius
 
-        cm.create_perturb_auf(self.files_per_auf_sim)
+        cm.create_perturb_auf()
 
         perturb_auf_combo = '{}-{}-{}'.format(ax1, ax2, self.filters[0])
         fracs = cm.b_perturb_auf_outputs[perturb_auf_combo]['frac']

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -506,85 +506,78 @@ class TestMakePerturbAUFs():
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
                               delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1, run_fw=1,
                               run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1)
-        with pytest.raises(ValueError, match='compute_local_density must be given if ' +
+        with pytest.raises(ValueError, match='density_radius must be given if ' +
                            'include_perturb_auf is True'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
                               delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1, run_fw=1,
                               run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1)
-        with pytest.raises(ValueError, match='density_radius must be given if ' +
-                           'include_perturb_auf and compute_local_density are both True'):
-            make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
-                              tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=True, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, run_fw=1, run_psf=1, dd_params=1,
-                              l_cut=1, snr_mag_params=1, al_avs=1)
         with pytest.raises(ValueError, match='fit_gal_flag must not be None if include_'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, run_fw=1, run_psf=1, dd_params=1,
-                              l_cut=1, snr_mag_params=1, al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1, run_fw=1,
+                              run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1,
+                              density_radius=1)
         with pytest.raises(ValueError, match='cmau_array must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, run_fw=1, run_psf=1, dd_params=1,
-                              l_cut=1, snr_mag_params=1, fit_gal_flag=True, al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1, run_fw=1,
+                              run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, fit_gal_flag=True,
+                              al_avs=1, density_radius=1)
         with pytest.raises(ValueError, match='wavs must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1,
-                              run_fw=1, run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, run_fw=1, run_psf=1, dd_params=1,
+                              l_cut=1, snr_mag_params=1, al_avs=1, density_radius=1)
         with pytest.raises(ValueError, match='z_maxs must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              run_fw=1, run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, run_fw=1, run_psf=1,
+                              dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1, density_radius=1)
         with pytest.raises(ValueError, match='nzs must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              z_maxs=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1,
-                              al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, z_maxs=1, run_fw=1,
+                              run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1,
+                              density_radius=1)
         with pytest.raises(ValueError, match='ab_offsets must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              z_maxs=1, nzs=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1,
-                              snr_mag_params=1, al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, z_maxs=1, nzs=1, run_fw=1,
+                              run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, al_avs=1,
+                              density_radius=1)
         with pytest.raises(ValueError, match='filter_names must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              z_maxs=1, nzs=1, ab_offsets=1, run_fw=1, run_psf=1, dd_params=1,
-                              l_cut=1, snr_mag_params=1, al_avs=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, z_maxs=1, nzs=1,
+                              ab_offsets=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1,
+                              snr_mag_params=1, al_avs=1, density_radius=1)
         with pytest.raises(ValueError, match='alpha0 must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, run_fw=1,
-                              run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, z_maxs=1, nzs=1,
+                              ab_offsets=1, filter_names=1, al_avs=1, run_fw=1, run_psf=1,
+                              dd_params=1, l_cut=1, snr_mag_params=1, density_radius=1)
         with pytest.raises(ValueError, match='alpha1 must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, alpha0=1,
-                              run_fw=1, run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, z_maxs=1, nzs=1,
+                              ab_offsets=1, filter_names=1, al_avs=1, alpha0=1, run_fw=1, run_psf=1,
+                              dd_params=1, l_cut=1, snr_mag_params=1, density_radius=1)
         with pytest.raises(ValueError, match='alpha_weight must be given if fit_gal_flag is True.'):
             make_perturb_aufs(*self.args, tri_set_name='WISE', tri_filt_num=1, tri_filt_names=1,
                               tri_maglim_faint=1, tri_num_faint=1, auf_region_frame=1,
-                              delta_mag_cuts=1, compute_local_density=False, psf_fwhms=1,
-                              num_trials=1, j0s=1, d_mag=1, fit_gal_flag=True, cmau_array=1, wavs=1,
-                              z_maxs=1, nzs=1, ab_offsets=1, filter_names=1, al_avs=1, alpha0=1,
-                              alpha1=1, run_fw=1, run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1)
+                              delta_mag_cuts=1, psf_fwhms=1, num_trials=1, j0s=1, d_mag=1,
+                              fit_gal_flag=True, cmau_array=1, wavs=1, z_maxs=1, nzs=1,
+                              ab_offsets=1, filter_names=1, al_avs=1, alpha0=1, alpha1=1, run_fw=1,
+                              run_psf=1, dd_params=1, l_cut=1, snr_mag_params=1, density_radius=1)
 
     @pytest.mark.remote_data
     def test_create_single_low_numbers(self):
@@ -643,8 +636,8 @@ class TestMakePerturbAUFs():
                 tri_filt_names=self.tri_filt_names, tri_maglim_faint=32, tri_num_faint=1000000,
                 auf_region_frame='galactic', psf_fwhms=self.psf_fwhms, num_trials=self.num_trials,
                 j0s=self.j0s, d_mag=d_mag, delta_mag_cuts=self.delta_mag_cuts,
-                compute_local_density=False, fit_gal_flag=False, density_radius=density_radius,
-                run_fw=True, run_psf=False, snr_mag_params=snr_mag_params, al_avs=[0])
+                fit_gal_flag=False, density_radius=density_radius, run_fw=True, run_psf=False,
+                snr_mag_params=snr_mag_params, al_avs=[0])
 
     @pytest.mark.remote_data
     def test_psf_algorithm(self):
@@ -740,7 +733,7 @@ class TestMakePerturbAUFs():
                 tri_filt_num=11, tri_filt_names=self.tri_filt_names, tri_maglim_faint=32,
                 tri_num_faint=1000000, auf_region_frame='galactic', psf_fwhms=self.psf_fwhms,
                 num_trials=self.num_trials, j0s=self.j0s, d_mag=d_mag,
-                delta_mag_cuts=self.delta_mag_cuts, compute_local_density=False, fit_gal_flag=False,
+                delta_mag_cuts=self.delta_mag_cuts, fit_gal_flag=False,
                 density_radius=density_radius, run_fw=run_fw, run_psf=True,
                 snr_mag_params=snr_mag_params, dd_params=dd_params, l_cut=l_cut, al_avs=[0])
 
@@ -781,7 +774,7 @@ class TestMakePerturbAUFs():
                                 prob_2_draw*2*df), rtol=0.1, atol=0.005)
 
     @pytest.mark.remote_data
-    def test_with_compute_local_density(self):
+    def test_compute_local_density(self):
         # Number of sources per PSF circle, on average, solved backwards to ensure
         # that local density ends up exactly in the middle of a count_array bin.
         # This should be approximately 0.076 sources per PSF circle.
@@ -915,7 +908,6 @@ class TestMakePerturbAUFs():
         cm.cross_match_extent = self.ax_lims
         cm.a_dens_dist = density_radius
         cm.b_dens_dist = density_radius
-        cm.compute_local_density = True
         cm.r = self.r
         cm.dr = self.dr
         cm.rho = self.rho
@@ -1117,8 +1109,6 @@ class TestMakePerturbAUFs():
 
         cm.chunk_id = 1
 
-        # Removing use_memmap_files means compute_local_density has to be True
-        cm.compute_local_density = True
         cm.a_dens_dist = density_radius
         cm.b_dens_dist = density_radius
 

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -581,16 +581,6 @@ class TestMakePerturbAUFs():
 
     @pytest.mark.remote_data
     def test_create_single_low_numbers(self):
-        # Number of sources per PSF circle, on average, solved backwards to ensure
-        # that local density ends up exactly in the middle of a count_array bin.
-        # This should be approximately 0.076 sources per PSF circle.
-        psf_mean = np.exp(8.7) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
-        # Local density is the controllable variable to ensure that we get
-        # the expected sources per PSF circle, with most variables cancelling
-        # mean divided by circle area sets the density needed.
-        local_dens = psf_mean / (np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2)
-        np.save('{}/local_N.npy'.format(self.auf_folder), np.array([[local_dens]] * 101))
-
         density_radius = np.sqrt(1 / np.pi / np.exp(8.7))
 
         np.save('{}/con_cat_astro.npy'.format(self.cat_folder), np.array([[0.3, 0.3, 0.1]] * 101))
@@ -645,11 +635,6 @@ class TestMakePerturbAUFs():
         # that local density ends up exactly in the middle of a count_array bin.
         # This should be approximately 0.15 sources per PSF circle.
         psf_mean = np.exp(9.38) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
-        # Local density is the controllable variable to ensure that we get
-        # the expected sources per PSF circle, with most variables cancelling
-        # mean divided by circle area sets the density needed.
-        local_dens = psf_mean / (np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2)
-        np.save('{}/local_N.npy'.format(self.auf_folder), np.array([[local_dens]] * 101))
 
         density_radius = np.sqrt(1 / np.pi / np.exp(9.38))
 
@@ -779,8 +764,7 @@ class TestMakePerturbAUFs():
         # that local density ends up exactly in the middle of a count_array bin.
         # This should be approximately 0.076 sources per PSF circle.
         psf_mean = np.exp(8.7) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
-        # This time we want to calculate the local density on the fly, but still
-        # get the same value we did in the without compute local density test. We
+        # We want to calculate the local density on the fly. We
         # therefore have to choose our "density radius" to set the appropriate
         # local density for our single source.
         density_radius = np.sqrt(1 / np.pi / np.exp(8.7))
@@ -953,11 +937,6 @@ class TestMakePerturbAUFs():
         # that local density ends up exactly in the middle of a count_array bin.
         # This should be approximately 0.076 sources per PSF circle.
         psf_mean = np.exp(8.7) * np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2
-        # Local density is the controllable variable to ensure that we get
-        # the expected sources per PSF circle, with most variables cancelling
-        # mean divided by circle area sets the density needed.
-        local_dens = psf_mean / (np.pi * (1.185 * self.psf_fwhms[0] / 3600)**2)
-        np.save('{}/local_N.npy'.format(self.auf_folder), np.array([[local_dens]] * 101))
 
         density_radius = np.sqrt(1 / np.pi / np.exp(8.7))
 

--- a/macauff/tests/test_perturbation_auf.py
+++ b/macauff/tests/test_perturbation_auf.py
@@ -36,7 +36,6 @@ class TestCreatePerturbAUF:
                                   os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         self.cm.a_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
         self.cm.b_auf_region_points = np.array([[0, 0], [50, 50]], dtype=float)
-        self.cm.mem_chunk_num = 4
 
     def test_no_perturb_outputs(self):
         # Randomly generate two catalogues (x3 files) between coordinates
@@ -418,14 +417,11 @@ class TestMakePerturbAUFs():
         self.num_trials = 50000
         self.j0s = mff.calc_j0(self.rho[:-1]+self.drho/2, self.r[:-1]+self.dr/2)
 
-        self.mem_chunk_num = 1
         self.delta_mag_cuts = np.array([10])
 
         self.args = [self.auf_folder, self.cat_folder, self.filters, self.auf_points,
                      self.r, self.dr, self.rho, self.drho, self.which_cat,
-                     self.include_perturb_auf, self.mem_chunk_num]
-
-        self.files_per_auf_sim = 7
+                     self.include_perturb_auf]
 
     def test_raise_value_errors(self):
         with pytest.raises(ValueError, match='tri_set_name must be given if include_perturb_auf ' +

--- a/macauff/tests/test_photometric_likelihood.py
+++ b/macauff/tests/test_photometric_likelihood.py
@@ -32,7 +32,6 @@ class TestOneSidedPhotometricLikelihood:
         self.mem_chunk_num = 2
         self.include_phot_like, self.use_phot_priors = False, False
 
-        os.makedirs('{}/phot_like'.format(self.joint_folder_path), exist_ok=True)
         os.makedirs(self.a_cat_folder_path, exist_ok=True)
         os.makedirs(self.b_cat_folder_path, exist_ok=True)
 
@@ -82,7 +81,6 @@ class TestOneSidedPhotometricLikelihood:
                       idx, new_line)
 
     def test_compute_photometric_likelihoods(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         Na, Nb, area = self.Na, self.Nb, self.area
         for folder, name in zip([self.a_cat_folder_path, self.b_cat_folder_path], ['a', 'b']):
             np.save('{}/con_cat_astro.npy'.format(folder), getattr(self, '{}_astro'.format(name)))
@@ -127,7 +125,6 @@ class TestOneSidedPhotometricLikelihood:
                     assert np.all(hist >= 250)
 
     def test_empty_filter(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         # This test simply removes all "good" flags from a single pointing-filter
         # combination, to check the robustness of empty bin derivations.
         a = np.copy(self.b_photo)
@@ -160,7 +157,6 @@ class TestOneSidedPhotometricLikelihood:
         assert_allclose(c_array, c_check, atol=1e-30)
 
     def test_small_number_bins(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         # This test checks if there are <N sources in a single pointing-filter
         # combination, then everything is simply lumped into one big bin.
         a = np.copy(self.b_photo)
@@ -196,7 +192,6 @@ class TestOneSidedPhotometricLikelihood:
         assert_allclose(c_array, c_check, atol=1e-30)
 
     def test_calculate_phot_like_input(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         # Here we also have to dump a random "magref" file to placate the
         # checks on CrossMatch.
         for folder, name in zip([self.a_cat_folder_path, self.b_cat_folder_path], ['a', 'b']):
@@ -367,7 +362,6 @@ class TestFullPhotometricLikelihood:
         self.mem_chunk_num = 2
         self.include_phot_like, self.use_phot_priors = True, True
 
-        os.makedirs('{}/phot_like'.format(self.joint_folder_path), exist_ok=True)
         os.makedirs(self.a_cat_folder_path, exist_ok=True)
         os.makedirs(self.b_cat_folder_path, exist_ok=True)
 
@@ -410,7 +404,6 @@ class TestFullPhotometricLikelihood:
         self.a_photo = ap
         self.b_photo = bp
 
-        os.system('rm -r {}/group/*'.format(self.joint_folder_path))
         # Have to pre-create the various overlap arrays, and integral lengths:
         asize = np.ones(self.Ntot, int)
         asize[~a_cut] = 0
@@ -442,7 +435,6 @@ class TestFullPhotometricLikelihood:
                                             bblen=bblen, bflen=bflen, binds=binds, bsize=bsize)
 
     def test_phot_like_prior_frac_inclusion(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         for ipl, upp in zip([False, True, True], [True, False, True]):
             for bf, ff in zip([None, 0.5, None], [0.5, None, None]):
                 msg = 'bright_frac' if bf is None else 'field_frac'
@@ -454,7 +446,6 @@ class TestFullPhotometricLikelihood:
                         bright_frac=bf, field_frac=ff)
 
     def test_compute_phot_like(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         for folder, name in zip([self.a_cat_folder_path, self.b_cat_folder_path], ['a', 'b']):
             np.save('{}/con_cat_astro.npy'.format(folder), getattr(self, '{}_astro'.format(name)))
             np.save('{}/con_cat_photo.npy'.format(folder), getattr(self, '{}_photo'.format(name)))
@@ -507,7 +498,6 @@ class TestFullPhotometricLikelihood:
         assert_allclose(c_l, fake_c_l, rtol=0.1, atol=0.05)
 
     def test_compute_phot_like_use_priors_only(self):
-        os.system('rm -r {}/phot_like/*'.format(self.joint_folder_path))
         for folder, name in zip([self.a_cat_folder_path, self.b_cat_folder_path], ['a', 'b']):
             np.save('{}/con_cat_astro.npy'.format(folder), getattr(self, '{}_astro'.format(name)))
             np.save('{}/con_cat_photo.npy'.format(folder), getattr(self, '{}_photo'.format(name)))

--- a/macauff/tests/test_photometric_likelihood.py
+++ b/macauff/tests/test_photometric_likelihood.py
@@ -29,7 +29,6 @@ class TestOneSidedPhotometricLikelihood:
 
         self.afilts, self.bfilts = np.array(['G', 'BP', 'RP']), np.array(['W1', 'W2', 'W3', 'W4'])
 
-        self.mem_chunk_num = 2
         self.include_phot_like, self.use_phot_priors = False, False
 
         os.makedirs(self.a_cat_folder_path, exist_ok=True)
@@ -58,20 +57,13 @@ class TestOneSidedPhotometricLikelihood:
 
             setattr(self, '{}_photo'.format(name), a)
 
-        old_line = 'mem_chunk_num = 10'
-        new_line = 'mem_chunk_num = 2\n'
+        old_line = 'cf_region_points = 131 134 4 -1 1 3'
+        new_line = 'cf_region_points = 131.5 133.5 3 -0.5 0.5 2\n'
         f = open(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt')).readlines()
         idx = np.where([old_line in line for line in f])[0][0]
         _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params.txt'),
                       idx, new_line, out_file=os.path.join(os.path.dirname(__file__),
                       'data/crossmatch_params_.txt'))
-        old_line = 'cf_region_points = 131 134 4 -1 1 3'
-        new_line = 'cf_region_points = 131.5 133.5 3 -0.5 0.5 2\n'
-        f = open(os.path.join(os.path.dirname(__file__),
-                 'data/crossmatch_params_.txt')).readlines()
-        idx = np.where([old_line in line for line in f])[0][0]
-        _replace_line(os.path.join(os.path.dirname(__file__), 'data/crossmatch_params_.txt'),
-                      idx, new_line)
         old_line = 'cross_match_extent = 131 138 -3 3'
         new_line = 'cross_match_extent = 131 134 -3 3\n'
         f = open(os.path.join(os.path.dirname(__file__),
@@ -87,7 +79,7 @@ class TestOneSidedPhotometricLikelihood:
             np.save('{}/con_cat_photo.npy'.format(folder), getattr(self, '{}_photo'.format(name)))
         pld = compute_photometric_likelihoods(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path, self.afilts,
-            self.bfilts, self.mem_chunk_num, self.cf_points, self.cf_areas, self.include_phot_like,
+            self.bfilts, self.cf_points, self.cf_areas, self.include_phot_like,
             self.use_phot_priors, self.group_sources_data)
 
         for a, shape, value in zip([pld.c_priors, pld.fa_priors, pld.fb_priors],
@@ -140,7 +132,7 @@ class TestOneSidedPhotometricLikelihood:
 
         pld = compute_photometric_likelihoods(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path, self.afilts,
-            self.bfilts, self.mem_chunk_num, self.cf_points, self.cf_areas, self.include_phot_like,
+            self.bfilts, self.cf_points, self.cf_areas, self.include_phot_like,
             self.use_phot_priors, self.group_sources_data)
 
         abinlen = pld.abinlengths
@@ -175,7 +167,7 @@ class TestOneSidedPhotometricLikelihood:
 
         pld = compute_photometric_likelihoods(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path, self.afilts,
-            self.bfilts, self.mem_chunk_num, self.cf_points, self.cf_areas, self.include_phot_like,
+            self.bfilts, self.cf_points, self.cf_areas, self.include_phot_like,
             self.use_phot_priors, self.group_sources_data)
 
         abinlen = pld.abinlengths
@@ -358,7 +350,6 @@ class TestFullPhotometricLikelihood:
 
         self.afilts, self.bfilts = np.array(['G']), np.array(['G'])
 
-        self.mem_chunk_num = 2
         self.include_phot_like, self.use_phot_priors = True, True
 
         os.makedirs(self.a_cat_folder_path, exist_ok=True)
@@ -440,9 +431,8 @@ class TestFullPhotometricLikelihood:
                 with pytest.raises(ValueError, match='{} must be supplied if '.format(msg)):
                     compute_photometric_likelihoods(
                         self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-                        self.afilts, self.bfilts, self.mem_chunk_num, self.cf_points,
-                        self.cf_areas, ipl, upp, self.group_sources_data,
-                        bright_frac=bf, field_frac=ff)
+                        self.afilts, self.bfilts, self.cf_points, self.cf_areas, ipl, upp,
+                        self.group_sources_data, bright_frac=bf, field_frac=ff)
 
     def test_compute_phot_like(self):
         for folder, name in zip([self.a_cat_folder_path, self.b_cat_folder_path], ['a', 'b']):
@@ -450,9 +440,9 @@ class TestFullPhotometricLikelihood:
             np.save('{}/con_cat_photo.npy'.format(folder), getattr(self, '{}_photo'.format(name)))
         pld = compute_photometric_likelihoods(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-            self.afilts, self.bfilts, self.mem_chunk_num, self.cf_points,
-            self.cf_areas, self.include_phot_like, self.use_phot_priors, self.group_sources_data,
-            bright_frac=self.Y_b, field_frac=self.Y_f)
+            self.afilts, self.bfilts, self.cf_points, self.cf_areas, self.include_phot_like,
+            self.use_phot_priors, self.group_sources_data, bright_frac=self.Y_b,
+            field_frac=self.Y_f)
 
         c_p = pld.c_priors
         c_l = pld.c_array
@@ -503,9 +493,9 @@ class TestFullPhotometricLikelihood:
         include_phot_like = False
         pld = compute_photometric_likelihoods(
             self.joint_folder_path, self.a_cat_folder_path, self.b_cat_folder_path,
-            self.afilts, self.bfilts, self.mem_chunk_num, self.cf_points,
-            self.cf_areas, include_phot_like, self.use_phot_priors, self.group_sources_data,
-            bright_frac=self.Y_b, field_frac=self.Y_f)
+            self.afilts, self.bfilts, self.cf_points, self.cf_areas, include_phot_like,
+            self.use_phot_priors, self.group_sources_data, bright_frac=self.Y_b,
+            field_frac=self.Y_f)
 
         c_p = pld.c_priors
         c_l = pld.c_array

--- a/macauff/tests/test_photometric_likelihood.py
+++ b/macauff/tests/test_photometric_likelihood.py
@@ -422,10 +422,6 @@ class TestFullPhotometricLikelihood:
         binds = -1*np.ones((1, self.Ntot), int, order='F')
         binds[0, :] = np.arange(0, self.Ntot)
         binds[0, ~b_cut] = -1
-        np.save('{}/group/ainds.npy'.format(self.joint_folder_path), ainds)
-        np.save('{}/group/asize.npy'.format(self.joint_folder_path), asize)
-        np.save('{}/group/binds.npy'.format(self.joint_folder_path), binds)
-        np.save('{}/group/bsize.npy'.format(self.joint_folder_path), bsize)
 
         # Integrate 2-D Gaussian to N*sigma radius gives probability Y of
         # 1 - exp(-0.5 N^2 sigma^2 / sigma^2) = 1 - exp(-0.5 N^2).
@@ -441,10 +437,6 @@ class TestFullPhotometricLikelihood:
         bblen[~b_cut] = 0
         bflen = N_f * np.sqrt(asig**2 + bsig**2) * np.ones(self.Ntot, float) / 3600
         bflen[~b_cut] = 0
-        np.save('{}/group/ablen.npy'.format(self.joint_folder_path), ablen)
-        np.save('{}/group/aflen.npy'.format(self.joint_folder_path), aflen)
-        np.save('{}/group/bblen.npy'.format(self.joint_folder_path), bblen)
-        np.save('{}/group/bflen.npy'.format(self.joint_folder_path), bflen)
 
         self.group_sources_data = StageData(ablen=ablen, aflen=aflen, ainds=ainds, asize=asize,
                                             bblen=bblen, bflen=bflen, binds=binds, bsize=bsize)

--- a/macauff/tests/test_photometric_likelihood.py
+++ b/macauff/tests/test_photometric_likelihood.py
@@ -207,8 +207,7 @@ class TestOneSidedPhotometricLikelihood:
                                   os.path.join(os.path.dirname(__file__), 'data/cat_b_params.txt'))
         self.cm.group_sources_data = self.group_sources_data
         self.cm.chunk_id = 1
-        files_per_phot = 6
-        self.cm.calculate_phot_like(files_per_phot)
+        self.cm.calculate_phot_like()
 
         abinlen = self.cm.phot_like_data.abinlengths
         bbinlen = self.cm.phot_like_data.bbinlengths

--- a/macauff/tests/test_photometric_likelihood.py
+++ b/macauff/tests/test_photometric_likelihood.py
@@ -22,8 +22,8 @@ class TestOneSidedPhotometricLikelihood:
         self.joint_folder_path = 'test_path'
         self.a_cat_folder_path = 'gaia_folder'
         self.b_cat_folder_path = 'wise_folder'
-        self.group_sources_data = StageData(ablen=None, ainds=None, asize=None,
-                                            bblen=None, binds=None, bsize=None)
+        self.group_sources_data = StageData(ablen=None, aflen=None, ainds=None, asize=None,
+                                            bblen=None, bflen=None, binds=None, bsize=None)
 
         self.area = (134-131)*(1--1)
 


### PR DESCRIPTION
PR removes the option (and complications thereof) to split up a large dataset by memmapping the catalogue and slicing from on disk. This removes `use_memmap_files` as an argument, but also removes the four `run_` config parameters, as well as removing `mem_chunk_num` as a config parameter, and streamlining numerous loops over parts of the dataset at a time.

With this the only option to break up a dataset too large for memory is to use the chunking distribution.