### PR TITLE
Allow asv run to succeed with failed benchmarks

### DIFF
--- a/.github/workflows/asv-main.yml
+++ b/.github/workflows/asv-main.yml
@@ -66,7 +66,7 @@ jobs:
           mv ../_results .
         fi
     - name: Run ASV for the main branch
-      run: asv run ALL --skip-existing --verbose
+      run: asv run ALL --skip-existing --verbose || true
     - name: Submit new results to the "benchmarks" branch
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/.github/workflows/publish-benchmarks-pr.yml
+++ b/.github/workflows/publish-benchmarks-pr.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Extract artifacts information
       id: pr-info
       run: |
-        printf "PR number: $(cat pr)"
-        printf "Output:\n $(cat output)"
+        printf "PR number: $(cat pr)\n"
+        printf "Output:\n$(cat output)"
         printf "pr=$(cat pr)" >> $GITHUB_OUTPUT
     - name: Find benchmarks comment
       uses: peter-evans/find-comment@v2


### PR DESCRIPTION
Applies a small fix to the `asv-main` workflow, allowing the `asv run` command to succeed even when it fails to compute benchmarks on a commit. It also improves the log output of the `publish-benchmarks-pr` workflow.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation