### PR TITLE
Add black/isort interop options.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,11 @@ sdist.include = ["src/macauff/_version.py"]
 
 [tool.setuptools_scm]
 write_to = "src/macauff/_version.py"
+
+[tool.black]
+line-length = 110
+target-version = ["py38"]
+
+[tool.isort]
+profile = "black"
+line_length = 110


### PR DESCRIPTION
## Change Description

Adds project-level options for isort and black execution.

This extends the maximum line length to a more agreeable 110, if that's alright. This encourages isort to re-format the import lines in a way that will be consistent with black formatting.

You can autoformat the whole code base with:

```
$ black .
$ isort .
```