### PR TITLE
Break out data generation.

### DIFF
--- a/src/macauff/utils.py
+++ b/src/macauff/utils.py
@@ -1,16 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE
-'''
+"""
 This module provides testing utility functionality for the package.
-'''
+"""
 
 import os
 
 import numpy as np
 
 
-def generate_random_data(n_a, n_b, n_c, extent, n_a_filts, n_b_filts, a_astro_sig, b_astro_sig,
-                         a_cat, b_cat, seed=None):
-    '''
+def generate_random_data(
+    n_a, n_b, n_c, extent, n_a_filts, n_b_filts, a_astro_sig, b_astro_sig, a_cat, b_cat, seed=None
+):
+    """
     Convenience function to allow for the generation of two test datasets.
 
     Parameters
@@ -42,7 +43,72 @@ def generate_random_data(n_a, n_b, n_c, extent, n_a_filts, n_b_filts, a_astro_si
         Random number generator seed. If ``None``, will be passed to
         ``np.random.default_rng`` as such, and a seed will be generated
         as per ``default_rng``'s documentation.
-    '''
+    """
+    (
+        a_astro,
+        b_astro,
+        a_photo,
+        b_photo,
+        amagref,
+        bmagref,
+        a_pair_indices,
+        b_pair_indices,
+    ) = generate_random_catalogs(n_a, n_b, n_c, extent, n_a_filts, n_b_filts, a_astro_sig, b_astro_sig, seed)
+
+    for f in [a_cat, b_cat]:
+        os.makedirs(f, exist_ok=True)
+    np.save(f"{a_cat}/con_cat_astro.npy", a_astro)
+    np.save(f"{b_cat}/con_cat_astro.npy", b_astro)
+    np.save(f"{a_cat}/con_cat_photo.npy", a_photo)
+    np.save(f"{b_cat}/con_cat_photo.npy", b_photo)
+    np.save(f"{a_cat}/magref.npy", amagref)
+    np.save(f"{b_cat}/magref.npy", bmagref)
+
+    # Fake uninformative "overlap" flag data, where no sources are in the
+    # halo of the chunk.
+    np.save(f"{a_cat}/in_chunk_overlap.npy", np.zeros(n_a, bool))
+    np.save(f"{b_cat}/in_chunk_overlap.npy", np.zeros(n_b, bool))
+
+    np.save(f"{a_cat}/test_match_indices.npy", a_pair_indices)
+    np.save(f"{b_cat}/test_match_indices.npy", b_pair_indices)
+
+
+def generate_random_catalogs(
+    n_a, n_b, n_c, extent, n_a_filts, n_b_filts, a_astro_sig, b_astro_sig, seed=None
+):
+    """
+    Convenience function to allow for the generation of two test datasets.
+
+    Parameters
+    ----------
+    n_a : integer
+        The number of sources to be generated in catalogue "a".
+    n_b : integer
+        The number of catalogue "b" fake sources.
+    n_c : integer
+        The number of common, overlapping sources, in both catalogues.
+    extent : list of integers
+        The on-sky coordinates that mark out the rectangular limits over which
+        sources should be generated. Should be of the form
+        ``[lower_lon, upper_lon, lower_lat, upper_lat]``, in degrees.
+    n_a_filts : integer
+        The number of photometric filters catalogue "a" should have.
+    n_b_filts : integer
+        The number of catalogue "b" photometric filters.
+    a_astro_sig : float
+        The astrometric uncertainty of catalogue "a", in arcseconds.
+    b_astro_sig : float
+        Catalogue "b"'s astrometric uncertainty, in arcseconds.
+    a_cat : string
+        The folder path into which to save the binary files containing
+        catalogue "a"'s astrometric and photometric data.
+    b_cat : string
+        Folder describing the save location of catalogue "b"'s data.
+    seed : integer, optional
+        Random number generator seed. If ``None``, will be passed to
+        ``np.random.default_rng`` as such, and a seed will be generated
+        as per ``default_rng``'s documentation.
+    """
     if n_a > n_b:
         raise ValueError("n_a must be smaller or equal to n_b.")
     if n_c > n_a:
@@ -93,19 +159,4 @@ def generate_random_data(n_a, n_b, n_c, extent, n_a_filts, n_b_filts, a_astro_si
     amagref = rng.choice(n_a_filts, size=n_a)
     bmagref = rng.choice(n_b_filts, size=n_b)
 
-    for f in [a_cat, b_cat]:
-        os.makedirs(f, exist_ok=True)
-    np.save(f'{a_cat}/con_cat_astro.npy', a_astro)
-    np.save(f'{b_cat}/con_cat_astro.npy', b_astro)
-    np.save(f'{a_cat}/con_cat_photo.npy', a_photo)
-    np.save(f'{b_cat}/con_cat_photo.npy', b_photo)
-    np.save(f'{a_cat}/magref.npy', amagref)
-    np.save(f'{b_cat}/magref.npy', bmagref)
-
-    # Fake uninformative "overlap" flag data, where no sources are in the
-    # halo of the chunk.
-    np.save(f'{a_cat}/in_chunk_overlap.npy', np.zeros(n_a, bool))
-    np.save(f'{b_cat}/in_chunk_overlap.npy', np.zeros(n_b, bool))
-
-    np.save(f'{a_cat}/test_match_indices.npy', a_pair_indices)
-    np.save(f'{b_cat}/test_match_indices.npy', b_pair_indices)
+    return a_astro, b_astro, a_photo, b_photo, amagref, bmagref, a_pair_indices, b_pair_indices


### PR DESCRIPTION
## Change Description

Related to https://github.com/macauff/lsdb_macauff/issues/5

## Solution Description

Splits random data generation into a method that generates the data, and an outer method to generate data and save it in npy format. 

An upcoming PR in lsdb_macauff will use the inner method to generate some test data, but will write a unified catalog CSV out instead if individual npy files.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation