### PR TITLE
Fix pytest warnings

### DIFF
--- a/src/macauff/derive_psf_auf_params.py
+++ b/src/macauff/derive_psf_auf_params.py
@@ -861,7 +861,7 @@ class FitPSFPerturbations:
                 diff[i, 2] = _li
                 diff[i, 3] = x
                 diff[i, 4] = dx
-                diff[i, 5] = dx_fit
+                diff[i, 5] = dx_fit[0]
 
         pool.join()
 

--- a/src/macauff/get_trilegal_wrapper.py
+++ b/src/macauff/get_trilegal_wrapper.py
@@ -169,8 +169,8 @@ def trilegal_webcall(trilegal_version, l, b, area, binaries, av, sigma_av, filte
     while not complete:  # pylint: disable=too-many-nested-blocks
         notconnected = True
         busy = True
-        print("TRILEGAL is being called with \n l={l} deg, b={b} deg, area={area} sqrdeg\n "
-              "Av={av} with {sigma_av} fractional r.m.s. spread \n in the {filterset} system, complete "
+        print(f"TRILEGAL is being called with \n l={l} deg, b={b} deg, area={area} sqrdeg\n "
+              f"Av={av} with {sigma_av} fractional r.m.s. spread \n in the {filterset} system, complete "
               f"down to mag={maglim} in its {magnum}th filter, use_binaries set to {binaries}.")
         sp.Popen(cmd, shell=True).wait()  # pylint: disable=consider-using-with
         if (os.path.exists(f'{outfolder}/tmpfile') and

--- a/src/macauff/group_sources.py
+++ b/src/macauff/group_sources.py
@@ -411,8 +411,7 @@ def _clean_overlaps(inds, size, n_pool):
             y = len(unique_inds)
             inds[:y, i] = unique_inds
             inds[y:, i] = -1
-            if y > maxsize:
-                maxsize = y
+            maxsize = max(maxsize, y)
             size[i] = y
 
     pool.join()

--- a/src/macauff/parse_catalogue.py
+++ b/src/macauff/parse_catalogue.py
@@ -284,9 +284,9 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     match_df = pd.DataFrame(columns=cols, index=np.arange(0, n_matches))
 
     for i in column_name_lists[0]:
-        match_df[i].iloc[:] = cat_a[i].iloc[ac].values
+        match_df.loc[:, i] = cat_a.loc[ac, i].values
     for i in column_name_lists[1]:
-        match_df[i].iloc[:] = cat_b[i].iloc[bc].values
+        match_df.loc[:, i] = cat_b.loc[bc, i].values
     match_df.iloc[:, 6+n_amags+n_bmags] = p
     match_df.iloc[:, 6+n_amags+n_bmags+1] = seps
     match_df.iloc[:, 6+n_amags+n_bmags+2] = eta
@@ -299,10 +299,10 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
         match_df.iloc[:, 6+n_amags+n_bmags+6+acontprob.shape[0]+i] = bcontprob[i, :]
     if extra_col_name_lists[0] is not None:
         for i in extra_col_name_lists[0]:
-            match_df[i].iloc[:] = cat_a[i].iloc[ac].values
+            match_df.loc[:, i] = cat_a.loc[ac, i].values
     if extra_col_name_lists[1] is not None:
         for i in extra_col_name_lists[1]:
-            match_df[i].iloc[:] = cat_b[i].iloc[bc].values
+            match_df.loc[:, i] = cat_b.loc[bc, i].values
 
     # FIT_SIG are the last 0-2 columns, after [ID+coords(x2)+mag(xN)]x2 +
     # Q match-made columns, plus len(extra_col_name_lists)x2.
@@ -339,7 +339,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     n_anonmatches = len(af)
     a_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_anonmatches))
     for i in column_name_lists[0]:
-        a_nonmatch_df[i].iloc[:] = cat_a[i].iloc[af].values
+        a_nonmatch_df.loc[:, i] = cat_a.loc[af, i].values
     a_nonmatch_df.iloc[:, 3+n_amags] = p
     a_nonmatch_df.iloc[:, 3+n_amags+1] = seps
     a_nonmatch_df.iloc[:, 3+n_amags+2] = afeta
@@ -347,7 +347,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     a_nonmatch_df.iloc[:, 3+n_amags+4] = a_avg_cont
     if extra_col_name_lists[0] is not None:
         for i in extra_col_name_lists[0]:
-            a_nonmatch_df[i].iloc[:] = cat_a[i].iloc[af].values
+            a_nonmatch_df.loc[:, i] = cat_a.loc[af, i].values
 
     if input_npy_folders[0] is not None:
         ind = (len(column_name_lists[0]) + len(our_columns) +
@@ -373,7 +373,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     n_bnonmatches = len(bf)
     b_nonmatch_df = pd.DataFrame(columns=cols, index=np.arange(0, n_bnonmatches))
     for i in column_name_lists[1]:
-        b_nonmatch_df[i].iloc[:] = cat_b[i].iloc[bf].values
+        b_nonmatch_df.loc[:, i] = cat_b.loc[bf, i].values
     b_nonmatch_df.iloc[:, 3+n_bmags] = p
     b_nonmatch_df.iloc[:, 3+n_bmags+1] = seps
     b_nonmatch_df.iloc[:, 3+n_bmags+2] = bfeta
@@ -381,7 +381,7 @@ def npy_to_csv(input_csv_folders, input_match_folder, output_folder, csv_filenam
     b_nonmatch_df.iloc[:, 3+n_bmags+4] = b_avg_cont
     if extra_col_name_lists[1] is not None:
         for i in extra_col_name_lists[1]:
-            b_nonmatch_df[i].iloc[:] = cat_b[i].iloc[bf].values
+            b_nonmatch_df.loc[:, i] = cat_b.loc[bf, i].values
 
     if input_npy_folders[1] is not None:
         ind = (len(column_name_lists[1]) + len(our_columns) +

--- a/tests/macauff/test_counterpart_pairing.py
+++ b/tests/macauff/test_counterpart_pairing.py
@@ -4,6 +4,7 @@ Tests for the "counterpart_pairing" module.
 '''
 
 import itertools
+import math
 import os
 
 import numpy as np
@@ -662,7 +663,7 @@ class TestCounterpartPairing:  # pylint: disable=too-many-instance-attributes
 def test_f90_comb():
     for n in [2, 3, 4, 5]:
         for k in range(2, n+1, 1):
-            n_combs = np.math.factorial(n) / np.math.factorial(k) / np.math.factorial(n - k)
+            n_combs = math.factorial(n) / math.factorial(k) / math.factorial(n - k)
             combs = cpf.calc_combs(n, n_combs, k).T
             new_combs = combs[np.lexsort([combs[:, i] for i in range(k)])]
 
@@ -674,8 +675,8 @@ def test_f90_comb():
 def test_f90_perm_comb():
     for n in [2, 3, 4, 5]:
         for k in range(2, n+1, 1):
-            n_combs = np.math.factorial(n) / np.math.factorial(k) / np.math.factorial(n - k)
-            n_perms_per_comb = np.math.factorial(k)
+            n_combs = math.factorial(n) / math.factorial(k) / math.factorial(n - k)
+            n_perms_per_comb = math.factorial(k)
             perms = cpf.calc_permcombs(n, k, n_perms_per_comb, n_combs).T
             new_perms = perms[np.lexsort([perms[:, i] for i in range(k)])]
 
@@ -688,12 +689,12 @@ def test_f90_perm_comb():
 
 def test_factorial():
     for k in range(21):
-        assert np.math.factorial(k) == cpf.factorial(k, k-1)
-        assert np.math.factorial(k) == cpf.factorial(k, k)
+        assert math.factorial(k) == cpf.factorial(k, k-1)
+        assert math.factorial(k) == cpf.factorial(k, k)
 
     for k in range(21):
         assert cpf.factorial(k, 1) == k
 
     for k in range(21):
         for l in range(1, k+1):
-            assert cpf.factorial(k, l) == np.math.factorial(k) / np.math.factorial(k - l)
+            assert cpf.factorial(k, l) == math.factorial(k) / math.factorial(k - l)

--- a/tests/macauff/test_make_set_list.py
+++ b/tests/macauff/test_make_set_list.py
@@ -4,6 +4,7 @@ Tests for the "make_set_list" module.
 '''
 
 import os
+import warnings
 
 import numpy as np
 import pytest
@@ -55,11 +56,10 @@ def test_set_list_maximum_exceeded():
                               f'{n_b}/{n_b+2} catalogue b stars'):
                 alist, blist, agrplen, bgrplen, _, _ = set_list(a_overlaps, b_overlaps, a_num, b_num, 2)
         else:
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
                 # pylint: disable-next=unbalanced-tuple-unpacking
                 alist, blist, agrplen, bgrplen = set_list(a_overlaps, b_overlaps, a_num, b_num, 2)
-            # Should be empty if no warnings were raised.
-            assert not record
         if i != 2:
             assert np.all(agrplen == np.array([1, 1, 0]))
             assert np.all(bgrplen == np.array([1, 0, 1]))

--- a/tests/macauff/test_perturbation_auf.py
+++ b/tests/macauff/test_perturbation_auf.py
@@ -5,6 +5,7 @@ Tests for the "perturbation_auf" module.
 
 # pylint: disable=too-many-lines,duplicate-code
 
+import math
 import os
 
 import numpy as np
@@ -102,9 +103,9 @@ class TestCreatePerturbAUF:
 def test_perturb_aufs():
     # Poisson distribution with mean 0.08 gives 92.3% zero, 7.4% one, and 0.3% two draws.
     mean = 0.08
-    prob_0_draw = mean**0 * np.exp(-mean) / np.math.factorial(0)
-    prob_1_draw = mean**1 * np.exp(-mean) / np.math.factorial(1)
-    prob_2_draw = mean**2 * np.exp(-mean) / np.math.factorial(2)
+    prob_0_draw = mean**0 * np.exp(-mean) / math.factorial(0)
+    prob_1_draw = mean**1 * np.exp(-mean) / math.factorial(1)
+    prob_2_draw = mean**2 * np.exp(-mean) / math.factorial(2)
 
     n = np.array([1.0])
     m = np.array([0.0])
@@ -553,9 +554,9 @@ class TestMakePerturbAUFs():
                           'trilegal_auf_simulation_faint.dat', "w", encoding='utf-8') as f:
                     f.write(text)
 
-            prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / np.math.factorial(0)
-            prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / np.math.factorial(1)
-            prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / np.math.factorial(2)
+            prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / math.factorial(0)
+            prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / math.factorial(1)
+            prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / math.factorial(2)
 
             ax1, ax2 = self.auf_points[0]
 
@@ -701,9 +702,9 @@ class TestMakePerturbAUFs():
                       'trilegal_auf_simulation_faint.dat', "w", encoding='utf-8') as f:
                 f.write(text)
 
-        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / np.math.factorial(0)
-        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / np.math.factorial(1)
-        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / np.math.factorial(2)
+        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / math.factorial(0)
+        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / math.factorial(1)
+        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / math.factorial(2)
 
         ax1, ax2 = self.auf_points[0]
 
@@ -927,9 +928,9 @@ class TestMakePerturbAUFs():
                       'trilegal_auf_simulation_faint.dat', "w", encoding='utf-8') as f:
                 f.write(text)
 
-        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / np.math.factorial(0)
-        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / np.math.factorial(1)
-        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / np.math.factorial(2)
+        prob_0_draw = psf_mean**0 * np.exp(-psf_mean) / math.factorial(0)
+        prob_1_draw = psf_mean**1 * np.exp(-psf_mean) / math.factorial(1)
+        prob_2_draw = psf_mean**2 * np.exp(-psf_mean) / math.factorial(2)
 
         ax1, ax2 = self.auf_points[0]
 


### PR DESCRIPTION
Small PR to just remove accumulated `pytest` warnings from summary.

Passing `None` to `pytest`'s warnings was deprecated, resulting in a warning and subsequent error; `numpy` no longer cast 1-sized arrays to scalars; and `pandas` will eventually stop accepting slice copying.

All simply code-tidy to do equivalent, minor things in ways that the upstream codebases would prefer you do them in.