### PR TITLE
Fixed issue with photometric priors in dense fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New Features
 Bug Fixes
 ^^^^^^^^^
 
+- Fixed an issue where, in very crowded but asymetrically dense fields, photometric
+  priors could become negative. [#86]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -130,7 +130,7 @@ Determines how many CPUs are used when parallelising within ``Python`` using ``m
 
 ``int_fracs``
 
-The integral fractions of the various so-called "error circles" used in the cross-match process. Should be space-separated floats, in the order of: bright error circle fraction, "field" error circle fraction, and potential counterpart cutoff limit.
+The integral fractions of the various so-called "error circles" used in the cross-match process. Should be space-separated floats, in the order of: bright error circle fraction, "field" error circle fraction, and potential counterpart cutoff limit. Note that bright and "field" fractions should be reasonably separated in value (more than maybe 0.1) to avoid biasing results that use both to measure photometry-based priors, when applicable.
 
 ``output_csv_folder``
 

--- a/src/macauff/fit_astrometry.py
+++ b/src/macauff/fit_astrometry.py
@@ -1804,7 +1804,7 @@ class AstrometricCorrections:  # pylint: disable=too-many-instance-attributes
                         f_val = nn_frac_mn if j == 0 else nn_frac_quot if j == 3 else nn_frac_ind
                         h_str = f', H = {h:.2f}' if j == 0 else ''
                         if usetex:
-                            lab = rf'\sigma_\mathrm{{{sig_type}}} = {sig_val:.4f}", F = {f_val:.2f}{h_str}'
+                            lab = rf'$\sigma_\mathrm{{{sig_type}}}$ = {sig_val:.4f}", F = {f_val:.2f}{h_str}'
                         else:
                             lab = rf'sigma_{sig_type} = {sig_val:.4f}", F = {f_val:.2f}{h_str}'
                     else:

--- a/src/macauff/group_sources.py
+++ b/src/macauff/group_sources.py
@@ -205,17 +205,17 @@ def make_island_groupings(cm):
         a_fouriergrid = cm.a_perturb_auf_outputs['fourier_grid']
         b_fouriergrid = cm.b_perturb_auf_outputs['fourier_grid']
 
-        a_int_lens = gsf.get_integral_length(
+        a_int_areas = gsf.get_integral_length(
             a_err, b_err, cm.r[:-1]+cm.dr/2, cm.rho[:-1], cm.drho, cm.j1s, a_fouriergrid, b_fouriergrid,
             cm.a_modelrefinds, cm.b_modelrefinds, ainds, asize, cm.int_fracs[0:2])
-        ablen = a_int_lens[:, 0]
-        aflen = a_int_lens[:, 1]
+        ab_area = a_int_areas[:, 0]
+        af_area = a_int_areas[:, 1]
 
-        b_int_lens = gsf.get_integral_length(
+        b_int_areas = gsf.get_integral_length(
             b_err, a_err, cm.r[:-1]+cm.dr/2, cm.rho[:-1], cm.drho, cm.j1s, b_fouriergrid, a_fouriergrid,
             cm.b_modelrefinds, cm.a_modelrefinds, binds, bsize, cm.int_fracs[0:2])
-        bblen = b_int_lens[:, 0]
-        bflen = b_int_lens[:, 1]
+        bb_area = b_int_areas[:, 0]
+        bf_area = b_int_areas[:, 1]
 
     t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     print(f"{t} Rank {cm.rank}, chunk {cm.chunk_id}: Maximum overlaps are:", amaxsize, bmaxsize)
@@ -317,10 +317,10 @@ def make_island_groupings(cm):
     agrplen = agrplen[passed_check]
     blist = blist[:, passed_check]
     bgrplen = bgrplen[passed_check]
-    # Only return aflen and bflen if they were created
+    # Only return a[bf]_area and b[bf]_area if they were created
     if not (cm.include_phot_like or cm.use_phot_priors):
-        ablen = bblen = None
-        aflen = bflen = None
+        ab_area = bb_area = None
+        af_area = bf_area = None
         auf_cdf_a = auf_cdf_b = None
     # Only return reject counts if they were created
     if num_a_failed_checks + a_first_rejected_len > 0:
@@ -337,14 +337,14 @@ def make_island_groupings(cm):
         lenrejectb = 0
         cm.reject_b = None
 
-    cm.ablen = ablen  # pylint: disable=possibly-used-before-assignment
-    cm.bblen = bblen  # pylint: disable=possibly-used-before-assignment
+    cm.ab_area = ab_area  # pylint: disable=possibly-used-before-assignment
+    cm.bb_area = bb_area  # pylint: disable=possibly-used-before-assignment
     cm.ainds = ainds
     cm.binds = binds
     cm.asize = asize
     cm.bsize = bsize
-    cm.aflen = aflen  # pylint: disable=possibly-used-before-assignment
-    cm.bflen = bflen  # pylint: disable=possibly-used-before-assignment
+    cm.af_area = af_area  # pylint: disable=possibly-used-before-assignment
+    cm.bf_area = bf_area  # pylint: disable=possibly-used-before-assignment
     cm.alist = alist
     cm.blist = blist
     cm.agrplen = agrplen

--- a/src/macauff/group_sources.py
+++ b/src/macauff/group_sources.py
@@ -15,8 +15,12 @@ import numpy as np
 # pylint: disable=import-error,no-name-in-module
 from macauff.group_sources_fortran import group_sources_fortran as gsf
 from macauff.make_set_list import set_list
-from macauff.misc_functions import (_load_rectangular_slice, hav_dist_constant_lat, load_small_ref_auf_grid,
-                                    SharedNumpyArray)
+from macauff.misc_functions import (
+    SharedNumpyArray,
+    _load_rectangular_slice,
+    hav_dist_constant_lat,
+    load_small_ref_auf_grid,
+)
 
 # pylint: enable=import-error,no-name-in-module
 

--- a/src/macauff/group_sources_fortran.f90
+++ b/src/macauff/group_sources_fortran.f90
@@ -179,6 +179,8 @@ subroutine get_overlap_indices(a_ax_1, a_ax_2, b_ax_1, b_ax_2, max_sep, amax, bm
 
     max_sep2 = max_sep**2
 
+    a_auf_cdf = 2
+    b_auf_cdf = 2
     aindices = -1
     bindices = -1
     anumoverlap = 0
@@ -192,6 +194,7 @@ subroutine get_overlap_indices(a_ax_1, a_ax_2, b_ax_1, b_ax_2, max_sep, amax, bm
     do j = 1, size(a_ax_1)
         tempind = -1
         tempcounter = 1
+        tempcdf = 2
         changeflag = 0
         oa = a_axerr(j)
         do i = 1, size(b_ax_1)
@@ -233,6 +236,7 @@ subroutine get_overlap_indices(a_ax_1, a_ax_2, b_ax_1, b_ax_2, max_sep, amax, bm
     do i = 1, size(b_ax_1)
         tempind = -1
         tempcounter = 1
+        tempcdf = 2
         changeflag = 0
         ob = b_axerr(i)
         do j = 1, size(a_ax_1)

--- a/src/macauff/group_sources_fortran.f90
+++ b/src/macauff/group_sources_fortran.f90
@@ -173,7 +173,9 @@ subroutine get_overlap_indices(a_ax_1, a_ax_2, b_ax_1, b_ax_2, max_sep, amax, bm
     ! Temporary flag arrays.
     integer :: tempcounter, changeflag
     ! Allocatable temporary index array.
-    integer, allocatable :: tempind(:), tempcdf(:)
+    integer, allocatable :: tempind(:)
+    ! Allocatable temporary CDF array.
+    real(dp), allocatable :: tempcdf(:)
 
     max_sep2 = max_sep**2
 

--- a/src/macauff/macauff.py
+++ b/src/macauff/macauff.py
@@ -139,7 +139,7 @@ class Macauff():
         '''
         t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         print(f'{t} Rank {self.cm.rank}, chunk {self.cm.chunk_id}: Calculating photometric region areas...')
-        dlon, dlat = 0.01, 0.01
+        dlon, dlat = 0.001, 0.001
         test_lons = np.arange(self.cm.cross_match_extent[0], self.cm.cross_match_extent[1], dlon)
         test_lats = np.arange(self.cm.cross_match_extent[2], self.cm.cross_match_extent[3], dlat)
 

--- a/src/macauff/misc_functions.py
+++ b/src/macauff/misc_functions.py
@@ -4,8 +4,9 @@ This module provides miscellaneous scripts, called in other parts of the cross-m
 framework.
 '''
 
-import numpy as np
 from multiprocessing import shared_memory
+
+import numpy as np
 from scipy.optimize import minimize
 
 __all__ = []

--- a/src/macauff/photometric_likelihood.py
+++ b/src/macauff/photometric_likelihood.py
@@ -389,8 +389,8 @@ def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_siz
 
     # Areas are reversed, so we remove the "a" areas from catalogue b and cut
     # them out of the density calculation for Nfa, and vice versa.
-    a_area = np.sum(b_flen[b_flags])
-    b_area = np.sum(a_flen[a_flags])
+    a_area = np.sum(np.pi * b_flen[b_flags]**2)
+    b_area = np.sum(np.pi * a_flen[a_flags]**2)
 
     nfa = num_fa/(area - a_area)
     nfb = num_fb/(area - b_area)
@@ -421,7 +421,7 @@ def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_siz
         _fb = hist / (np.sum(hist)*np.diff(b_bins))
         # We remove the objects from catalogue b, but it's the area of catalogue
         # a that is removed for density calculation purposes!
-        barea = np.sum(a_flen[a_flags & (a_mag >= a_bins[i]) & (a_mag <= a_bins[i+1])])
+        barea = np.sum(np.pi * a_flen[a_flags & (a_mag >= a_bins[i]) & (a_mag <= a_bins[i+1])]**2)
         _nfb = _num_fb/(area - barea)
         fm = np.append(0, np.cumsum(_fb[:-1] * np.diff(b_bins[:-1])))
         for j in range(0, len(b_bins)-1):

--- a/src/macauff/photometric_likelihood.py
+++ b/src/macauff/photometric_likelihood.py
@@ -127,10 +127,11 @@ def compute_photometric_likelihoods(cm):
                     bright_frac, field_frac = cm.int_fracs[[0, 1]]
                     c_prior, c_like, fa_prior, fa_like, fb_prior, fb_like = create_c_and_f(
                         # pylint: disable-next=possibly-used-before-assignment
-                        a_astro, b_astro, a_mag, b_mag, a_inds_cut, a_size_cut,
+                        a_mag, b_mag, a_inds_cut, a_size_cut, b_inds_cut, b_size_cut, a_b_area_cut,
                         # pylint: disable-next=possibly-used-before-assignment
-                        b_inds_cut, b_size_cut, a_b_area_cut, b_b_area_cut, a_f_area_cut, b_f_area_cut,
-                        a_auf_cdf, b_auf_cdf, a_bins, b_bins, bright_frac, field_frac, a_flags, b_flags, area)
+                        b_b_area_cut, a_f_area_cut, b_f_area_cut, a_auf_cdf, b_auf_cdf, a_bins, b_bins,
+                        # pylint: disable-next=possibly-used-before-assignment
+                        bright_frac, field_frac, a_flags, b_flags, area)
                 if cm.use_phot_priors and not cm.include_phot_like:
                     # If we only used the create_c_and_f routine to derive
                     # priors, then quickly update likelihoods here.
@@ -280,21 +281,15 @@ def make_bins(input_mags):
     return output_bins
 
 
-# pylint: disable-next=too-many-locals
-def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_b_area, b_b_area,
-                   a_f_area, b_f_area, auf_cdf_a, auf_cdf_b, a_bins, b_bins, bright_frac, field_frac, a_flags,
-                   b_flags, area):
+# pylint: disable-next=too-many-locals,too-many-arguments
+def create_c_and_f(a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_b_area, b_b_area, a_f_area, b_f_area,
+                   auf_cdf_a, auf_cdf_b, a_bins, b_bins, bright_frac, field_frac, a_flags, b_flags, area):
     '''
     Functionality to create the photometric likelihood and priors from a set
     of photometric data in a given pair of filters.
 
     Parameters
     ----------
-    a_astro : numpy.ndarray
-        Array of astrometric parameters for all catalogue "a" sources in this
-        given sky slice.
-    b_astro : numpy.ndarray
-        Astrometric parameters for small sky region catalogue "b" objects.
     a_mag : numpy.ndarray
         Catalogue "a" magnitudes for sky area.
     b_mag : numpy.ndarray
@@ -529,6 +524,7 @@ def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_siz
     # recover that below. Similarly, we can't allow for a dependency-based
     # density condition where Nc is set based on one Nf and then the other Nf
     # is set based on Nc, since we don't know which counterpart density to use.
+    # pylint: disable-next=too-many-boolean-expressions
     if (np.any(np.isnan([nc, nfa, nfb])) or (nc <= 0 and (nfa <= 0 or nfb <= 0)) or
             (nfa <= 0.01 * nc and nc <= 0.01 * nfb) or (nfb <= 0.01 * nc and nc <= 0.01 * nfa)):
         raise ValueError("Incorrect prior densities, unable to process chunk.")

--- a/src/macauff/photometric_likelihood.py
+++ b/src/macauff/photometric_likelihood.py
@@ -415,8 +415,10 @@ def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_siz
 
     measured_density_a = np.array([tot_density_a, *measured_density_a])
     measured_density_b = np.array([tot_density_b, *measured_density_b])
-    meas_dens_a_uncert = np.array([tot_dens_a_uncert, *meas_dens_a_uncert])
-    meas_dens_b_uncert = np.array([tot_dens_b_uncert, *meas_dens_b_uncert])
+    # Add a floor of 1/sq deg in quadrature to avoid empty measurements
+    # causing NaNs.
+    meas_dens_a_uncert = np.sqrt(np.array([tot_dens_a_uncert, *meas_dens_a_uncert])**2 + 1**2)
+    meas_dens_b_uncert = np.sqrt(np.array([tot_dens_b_uncert, *meas_dens_b_uncert])**2 + 1**2)
 
     # Filter for completely isolated sources, which will have zero area,
     # to take a meaningful sample.
@@ -482,8 +484,8 @@ def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_siz
 
         measured_density_a = np.array([tot_density_a, *measured_density_a])
         measured_density_b = np.array([tot_density_b, *measured_density_b])
-        meas_dens_a_uncert = np.array([tot_dens_a_uncert, *meas_dens_a_uncert])
-        meas_dens_b_uncert = np.array([tot_dens_b_uncert, *meas_dens_b_uncert])
+        meas_dens_a_uncert = np.sqrt(np.array([tot_dens_a_uncert, *meas_dens_a_uncert])**2 + 1**2)
+        meas_dens_b_uncert = np.sqrt(np.array([tot_dens_b_uncert, *meas_dens_b_uncert])**2 + 1**2)
 
         # Also filter the a-catalogue objects for being within our magnitude
         # range, but don't do anything to b, so re-use the previous one.
@@ -512,7 +514,8 @@ def create_c_and_f(a_astro, b_astro, a_mag, b_mag, a_inds, a_size, b_inds, b_siz
         # convert directly to X c, but we have split that out above into Nc
         # already. Here we therefore don't care about the constant in front
         # of c(m | m), and simply normalise.
-        cdmdm[:, i] /= np.sum(cdmdm[:, i] * np.diff(b_bins))
+        if np.sum(cdmdm[:, i] * np.diff(b_bins)) > 0:
+            cdmdm[:, i] /= np.sum(cdmdm[:, i] * np.diff(b_bins))
 
     integral = 0
     for i in range(0, len(a_bins)-1):

--- a/tests/macauff/test_group_sources.py
+++ b/tests/macauff/test_group_sources.py
@@ -250,8 +250,8 @@ class TestOverlap():
         assert np.all(b_inds == b_overlaps)
 
         fake_a_cdf = np.ones((a_max, len(self.a_ax_1)), float) * 2
-        for i in range(len(a_num)):
-            for j in range(a_num[i]):
+        for i, _anum in enumerate(a_num):
+            for j in range(_anum):
                 d = mff.haversine_wrapper(self.a_ax_1[i], self.b_ax_1[a_overlaps[j, i]-1], self.a_ax_2[i],
                                           self.b_ax_2[a_overlaps[j, i]-1])
                 fake_a_cdf[j, i] = 1 - np.exp(-0.5 * d**2 / ((self.a_axerr[i]**2 +
@@ -259,8 +259,8 @@ class TestOverlap():
         assert_allclose(a_cdf, fake_a_cdf, atol=1e-5, rtol=0.001)
 
         fake_b_cdf = np.ones((b_max, len(self.b_ax_1)), float) * 2
-        for i in range(len(b_num)):
-            for j in range(b_num[i]):
+        for i, _bnum in enumerate(b_num):
+            for j in range(_bnum):
                 d = mff.haversine_wrapper(self.b_ax_1[i], self.a_ax_1[b_overlaps[j, i]-1], self.b_ax_2[i],
                                           self.a_ax_2[b_overlaps[j, i]-1])
                 fake_b_cdf[j, i] = 1 - np.exp(-0.5 * d**2 / ((self.b_axerr[i]**2 +

--- a/tests/macauff/test_group_sources.py
+++ b/tests/macauff/test_group_sources.py
@@ -17,6 +17,7 @@ from macauff.group_sources_fortran import group_sources_fortran as gsf
 from macauff.macauff import Macauff
 from macauff.matching import CrossMatch
 from macauff.misc_functions import create_auf_params_grid
+from macauff.misc_functions_fortran import misc_functions_fortran as mff
 
 # pylint: enable=no-name-in-module,import-error
 
@@ -153,17 +154,17 @@ class TestFortranCode():
             ainds[:_asize, i] = rng.choice(len(b_err), size=_asize, replace=False)
         frac_array = np.array([0.63, 0.9])
 
-        int_dists = gsf.get_integral_length(a_err, b_err, self.r[:-1]+self.dr/2, self.rho[:-1],
+        int_areas = gsf.get_integral_length(a_err, b_err, self.r[:-1]+self.dr/2, self.rho[:-1],
                                             self.drho, self.j1s, a_fouriergrid, b_fouriergrid,
                                             amodrefind, bmodrefind, ainds, asize, frac_array)
 
-        assert np.all(int_dists.shape == (len(a_err), len(frac_array)))
+        assert np.all(int_areas.shape == (len(a_err), len(frac_array)))
         for i, frac in enumerate(frac_array):
             for j, aerr in enumerate(a_err):
-                _berr = np.amax(b_err[ainds[:, j]])
-                assert_allclose(int_dists[j, i]*3600, np.sqrt(-2 * (aerr**2 + _berr**2 +
-                                a_four_sig**2 + b_four_sig**2) * np.log(1 - frac)),
-                                rtol=1e-3, atol=self.dr[0]/2)
+                assert_allclose(np.sqrt(int_areas[j, i]/np.pi)*3600, np.mean(
+                    np.sqrt(-2 * (aerr**2 + b_err[ainds[:asize[j], j]]**2 +
+                                  a_four_sig**2 + b_four_sig**2) * np.log(1 - frac))),
+                    rtol=1e-3, atol=self.dr[0]/2)
 
 
 class TestOverlap():
@@ -225,7 +226,7 @@ class TestOverlap():
 
     def test_get_overlap_indices_fortran(self):
         a_max, b_max = 2, 2
-        a_inds, b_inds, a_num, b_num = gsf.get_overlap_indices(
+        a_inds, b_inds, a_num, b_num, a_cdf, b_cdf = gsf.get_overlap_indices(
             self.a_ax_1, self.a_ax_2, self.b_ax_1, self.b_ax_2, self.max_sep/3600, a_max, b_max,
             self.a_axerr, self.b_axerr, self.r[:-1]+self.dr/2, self.rho[:-1], self.drho, self.j1s,
             self.afouriergrid, self.bfouriergrid, self.amodrefind, self.bmodrefind, self.max_frac)
@@ -248,6 +249,24 @@ class TestOverlap():
         assert np.all(a_inds == a_overlaps)
         assert np.all(b_inds == b_overlaps)
 
+        fake_a_cdf = np.ones((a_max, len(self.a_ax_1)), float) * 2
+        for i in range(len(a_num)):
+            for j in range(a_num[i]):
+                d = mff.haversine_wrapper(self.a_ax_1[i], self.b_ax_1[a_overlaps[j, i]-1], self.a_ax_2[i],
+                                          self.b_ax_2[a_overlaps[j, i]-1])
+                fake_a_cdf[j, i] = 1 - np.exp(-0.5 * d**2 / ((self.a_axerr[i]**2 +
+                                                              self.b_axerr[a_overlaps[j, i]-1]**2)/3600**2))
+        assert_allclose(a_cdf, fake_a_cdf, atol=1e-5, rtol=0.001)
+
+        fake_b_cdf = np.ones((b_max, len(self.b_ax_1)), float) * 2
+        for i in range(len(b_num)):
+            for j in range(b_num[i]):
+                d = mff.haversine_wrapper(self.b_ax_1[i], self.a_ax_1[b_overlaps[j, i]-1], self.b_ax_2[i],
+                                          self.a_ax_2[b_overlaps[j, i]-1])
+                fake_b_cdf[j, i] = 1 - np.exp(-0.5 * d**2 / ((self.b_axerr[i]**2 +
+                                                              self.a_axerr[b_overlaps[j, i]-1]**2)/3600**2))
+        assert_allclose(b_cdf, fake_b_cdf, atol=1e-5, rtol=0.001)
+
 
 def test_clean_overlaps():
     maxsize, size = 5, np.array([3, 5, 3, 4, 4, 5, 4, 2, 5, 4]*3)
@@ -264,7 +283,7 @@ def test_clean_overlaps():
         inds[:, 8+10*i] = [2, 2, 2, 2, 2]
         inds[:, 9+10*i] = [1, 1, 2, 3, -1]
 
-    inds2, size2 = _clean_overlaps(inds, size, 2)
+    inds2, size2, cdf2 = _clean_overlaps(inds, size, inds*10, 2)
     compare_inds2 = np.empty((4, 30), int)
     for i in range(0, 3):
         compare_inds2[:, 0+10*i] = [0, 1, -1, -1]
@@ -279,6 +298,11 @@ def test_clean_overlaps():
         compare_inds2[:, 9+10*i] = [1, 2, 3, -1]
     assert np.all(inds2 == compare_inds2)
     assert np.all(size2 == np.array([2, 3, 3, 2, 4, 3, 2, 2, 1, 3]*3))
+    # Fake the CDF array with inds times 10, since it just needs to be
+    # a different array of the same shape.
+    fake_cdf2 = np.copy(compare_inds2*10)
+    fake_cdf2[fake_cdf2 == -10] = -1
+    assert np.all(cdf2 == fake_cdf2)
 
 
 class TestMakeIslandGroupings():  # pylint: disable=too-many-instance-attributes
@@ -619,10 +643,10 @@ class TestMakeIslandGroupings():  # pylint: disable=too-many-instance-attributes
         berr = np.load(f'{self.b_cat_folder_path}/con_cat_astro.npy')[:, 2]
 
         # pylint: disable=no-member
-        ablen = self.cm.ablen
-        aflen = self.cm.aflen
-        bblen = self.cm.bblen
-        bflen = self.cm.bflen
+        ab_area = self.cm.ab_area
+        af_area = self.cm.af_area
+        bb_area = self.cm.bb_area
+        bf_area = self.cm.bf_area
 
         asize = self.cm.asize
         ainds = self.cm.ainds
@@ -630,8 +654,8 @@ class TestMakeIslandGroupings():  # pylint: disable=too-many-instance-attributes
         binds = self.cm.binds
         # pylint: enable=no-member
 
-        for i, _ablen in enumerate(ablen):
-            d = _ablen*3600
+        for i, _ab_area in enumerate(ab_area):
+            d = np.sqrt(_ab_area/np.pi)*3600
             if asize[i] > 0:
                 _berr = np.amax(berr[ainds[:asize[i], i]])
                 real_d = np.sqrt(-2 * (aerr[i]**2 + _berr**2) * np.log(1 - self.int_fracs[0]))
@@ -640,8 +664,8 @@ class TestMakeIslandGroupings():  # pylint: disable=too-many-instance-attributes
                 # If there is no overlap in opposing catalogue objects, we should
                 # get a zero distance error circle.
                 assert d == 0
-        for i, _aflen in enumerate(aflen):
-            d = _aflen*3600
+        for i, _af_area in enumerate(af_area):
+            d = np.sqrt(_af_area/np.pi)*3600
             if asize[i] > 0:
                 _berr = np.amax(berr[ainds[:asize[i], i]])
                 real_d = np.sqrt(-2 * (aerr[i]**2 + _berr**2) * np.log(1 - self.int_fracs[1]))
@@ -649,16 +673,16 @@ class TestMakeIslandGroupings():  # pylint: disable=too-many-instance-attributes
             else:
                 assert d == 0
 
-        for i, _bblen in enumerate(bblen):
-            d = _bblen*3600
+        for i, _bb_area in enumerate(bb_area):
+            d = np.sqrt(_bb_area/np.pi)*3600
             if bsize[i] > 0:
                 _aerr = np.amax(aerr[binds[:bsize[i], i]])
                 real_d = np.sqrt(-2 * (berr[i]**2 + _aerr**2) * np.log(1 - self.int_fracs[0]))
                 assert_allclose(d, real_d, rtol=1e-3, atol=self.dr[0]/2)
             else:
                 assert d == 0
-        for i, _bflen in enumerate(bflen):
-            d = _bflen*3600
+        for i, _bf_area in enumerate(bf_area):
+            d = np.sqrt(_bf_area/np.pi)*3600
             if bsize[i] > 0:
                 _aerr = np.amax(aerr[binds[:bsize[i], i]])
                 real_d = np.sqrt(-2 * (berr[i]**2 + _aerr**2) * np.log(1 - self.int_fracs[1]))

--- a/tests/macauff/test_photometric_likelihood.py
+++ b/tests/macauff/test_photometric_likelihood.py
@@ -260,8 +260,8 @@ def test_get_field_dists_fortran():
     mask = plf.get_field_dists(auf_cdf, ainds, asize, fracs, aflags, amag, bflags, bmag,
                                lowmag, uppmag, lowmag, uppmag)
     test_mask = np.ones((10, len(fracs)), bool)
-    for i in range(len(fracs)):
-        test_mask[auf_cdf[0, :] <= fracs[i], i] = 0
+    for i, frac in enumerate(fracs):
+        test_mask[auf_cdf[0, :] <= frac, i] = 0
     assert np.all(mask == test_mask)
     assert np.sum(mask) > 0
 


### PR DESCRIPTION
In rare cases, with very imbalanced catalogue sizes, the derived photometric priors for counterparts and non-matched objects could become negative, due to the calculations used to derive priors not holding for such extreme cases. Here we correct the calculation, use the full derivation -- based on total density of objects at particular cut-off radii -- and ensure robust and valid priors even in extreme cases.