### PR TITLE
CI Fixes

### DIFF
--- a/src/macauff/group_sources.py
+++ b/src/macauff/group_sources.py
@@ -253,12 +253,12 @@ def make_island_groupings(cm):
     # look at whether any source has a sky separation of less than max_sep
     # from any of the four lines defining extent in orthogonal sky axes.
     counter = np.arange(0, alist.shape[1])
-    shared_a = SharedNumpyArray(a_full, 'a_full')
-    shared_b = SharedNumpyArray(b_full, 'b_full')
-    shared_alist = SharedNumpyArray(alist, 'alist')
-    shared_blist = SharedNumpyArray(blist, 'blist')
-    shared_agrplen = SharedNumpyArray(agrplen, 'agrplen')
-    shared_bgrplen = SharedNumpyArray(bgrplen, 'bgrplen')
+    shared_a = SharedNumpyArray(a_full, f'a_full_{cm.chunk_id}')
+    shared_b = SharedNumpyArray(b_full, f'b_full_{cm.chunk_id}')
+    shared_alist = SharedNumpyArray(alist, f'alist_{cm.chunk_id}')
+    shared_blist = SharedNumpyArray(blist, f'blis_{cm.chunk_id}t')
+    shared_agrplen = SharedNumpyArray(agrplen, f'agrplen_{cm.chunk_id}')
+    shared_bgrplen = SharedNumpyArray(bgrplen, f'bgrplen_{cm.chunk_id}')
     expand_constants = [itertools.repeat(item) for item in [
         shared_a, shared_b, shared_alist, shared_blist, shared_agrplen, shared_bgrplen,
         cm.cross_match_extent, max_sep]]

--- a/src/macauff/macauff.py
+++ b/src/macauff/macauff.py
@@ -148,7 +148,7 @@ class Macauff():
         test_coords = np.empty((len(test_lons), 2), float)
         test_coords[:, 0] = test_lons
 
-        for q, test_lat in enumerate(test_lats):
+        for test_lat in test_lats:
             test_coords[:, 1] = test_lat
 
             inds = mff.find_nearest_point(test_coords[:, 0], test_coords[:, 1],

--- a/src/macauff/macauff.py
+++ b/src/macauff/macauff.py
@@ -139,26 +139,30 @@ class Macauff():
         '''
         t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         print(f'{t} Rank {self.cm.rank}, chunk {self.cm.chunk_id}: Calculating photometric region areas...')
+        sys.stdout.flush()
         dlon, dlat = 0.001, 0.001
         test_lons = np.arange(self.cm.cross_match_extent[0], self.cm.cross_match_extent[1], dlon)
         test_lats = np.arange(self.cm.cross_match_extent[2], self.cm.cross_match_extent[3], dlat)
 
-        test_coords = np.array([[a, b] for a in test_lons for b in test_lats])
-
-        inds = mff.find_nearest_point(test_coords[:, 0], test_coords[:, 1],
-                                      self.cm.cf_region_points[:, 0], self.cm.cf_region_points[:, 1])
-
         cf_areas = np.zeros((len(self.cm.cf_region_points)), float)
+        test_coords = np.empty((len(test_lons), 2), float)
+        test_coords[:, 0] = test_lons
 
-        # Unit area of a sphere is cos(theta) dtheta dphi if theta goes from -90
-        # to +90 degrees (sin(theta) for 0 to 180 degrees). Note, however, that
-        # dtheta and dphi have to be in radians, so we have to convert the entire
-        # thing from degrees and re-convert at the end. Hence:
-        for i, ind in enumerate(inds):
-            theta = np.radians(test_coords[i, 1])
-            dtheta, dphi = dlat / 180 * np.pi, dlon / 180 * np.pi
-            # Remember to convert back to square degrees:
-            cf_areas[ind] += (np.cos(theta) * dtheta * dphi) * (180 / np.pi)**2
+        for q, test_lat in enumerate(test_lats):
+            test_coords[:, 1] = test_lat
+
+            inds = mff.find_nearest_point(test_coords[:, 0], test_coords[:, 1],
+                                          self.cm.cf_region_points[:, 0], self.cm.cf_region_points[:, 1])
+
+            # Unit area of a sphere is cos(theta) dtheta dphi if theta goes from -90
+            # to +90 degrees (sin(theta) for 0 to 180 degrees). Note, however, that
+            # dtheta and dphi have to be in radians, so we have to convert the entire
+            # thing from degrees and re-convert at the end. Hence:
+            for i, ind in enumerate(inds):
+                theta = np.radians(test_coords[i, 1])
+                dtheta, dphi = dlat / 180 * np.pi, dlon / 180 * np.pi
+                # Remember to convert back to square degrees:
+                cf_areas[ind] += (np.cos(theta) * dtheta * dphi) * (180 / np.pi)**2
 
         self.cm.cf_areas = cf_areas
 

--- a/src/macauff/perturbation_auf.py
+++ b/src/macauff/perturbation_auf.py
@@ -114,7 +114,7 @@ def make_perturb_aufs(cm, which_cat):
                                                 auf_points[:, 0], auf_points[:, 1])
 
     t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    print(f'{t} Rank {cm.rank}, chunk {cm.chunk_id}: Creating empirical perturbation AUFs for '
+    print(f'{t} Rank {cm.rank}, chunk {cm.chunk_id}: Creating empirical perturbation AUF PDFs for '
           f'catalogue "{which_cat}"...')
     sys.stdout.flush()
 

--- a/src/macauff/photometric_likelihood.py
+++ b/src/macauff/photometric_likelihood.py
@@ -281,7 +281,7 @@ def make_bins(input_mags):
     return output_bins
 
 
-# pylint: disable-next=too-many-locals,too-many-arguments
+# pylint: disable-next=too-many-locals,too-many-arguments,too-many-statements
 def create_c_and_f(a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_b_area, b_b_area, a_f_area, b_f_area,
                    auf_cdf_a, auf_cdf_b, a_bins, b_bins, bright_frac, field_frac, a_flags, b_flags, area):
     '''

--- a/src/macauff/photometric_likelihood.py
+++ b/src/macauff/photometric_likelihood.py
@@ -418,10 +418,24 @@ def create_c_and_f(a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_b_area, b_b_a
     # Filter for completely isolated sources, which will have zero area,
     # to take a meaningful sample.
     pc = [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]
-    avg_a_areas = np.array([np.percentile(a_b_area[a_b_area > 0], pc),
-                            np.percentile(a_f_area[a_f_area > 0], pc)]).T
-    avg_b_areas = np.array([np.percentile(b_b_area[b_b_area > 0], pc),
-                            np.percentile(b_f_area[b_f_area > 0], pc)]).T
+    if np.sum(a_b_area > 0) > 0:
+        aba_perc = np.percentile(a_b_area[a_b_area > 0], pc)
+    else:
+        aba_perc = np.zeros(len(pc), float)
+    if np.sum(a_f_area > 0) > 0:
+        afa_perc = np.percentile(a_f_area[a_f_area > 0], pc)
+    else:
+        afa_perc = np.zeros(len(pc), float)
+    if np.sum(b_b_area > 0) > 0:
+        bba_perc = np.percentile(b_b_area[b_b_area > 0], pc)
+    else:
+        bba_perc = np.zeros(len(pc), float)
+    if np.sum(b_f_area > 0) > 0:
+        bfa_perc = np.percentile(b_f_area[b_f_area > 0], pc)
+    else:
+        bfa_perc = np.zeros(len(pc), float)
+    avg_a_areas = np.array([aba_perc, afa_perc]).T
+    avg_b_areas = np.array([bba_perc, bfa_perc]).T
 
     # With a percentile in steps of 10 percentage points, each area will be
     # equally weighted with 1/10th of the objects.
@@ -484,8 +498,15 @@ def create_c_and_f(a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_b_area, b_b_a
 
         # Also filter the a-catalogue objects for being within our magnitude
         # range, but don't do anything to b, so re-use the previous one.
-        avg_a_areas = np.array([np.percentile(a_b_area[(a_b_area > 0) & a_mag_filter], pc),
-                                np.percentile(a_f_area[(a_f_area > 0) & a_mag_filter], pc)]).T
+        if np.sum(a_b_area > 0) > 0:
+            aba_perc = np.percentile(a_b_area[(a_b_area > 0) & a_mag_filter], pc)
+        else:
+            aba_perc = np.zeros(len(pc), float)
+        if np.sum(a_f_area > 0) > 0:
+            afa_perc = np.percentile(a_f_area[(a_f_area > 0) & a_mag_filter], pc)
+        else:
+            afa_perc = np.zeros(len(pc), float)
+        avg_a_areas = np.array([aba_perc, afa_perc]).T
         wht_a_areas = 0.1 * np.ones_like(avg_a_areas)
 
         res = minimize(calculate_prior_densities, args=(measured_density_a, measured_density_b,

--- a/src/macauff/photometric_likelihood.py
+++ b/src/macauff/photometric_likelihood.py
@@ -498,11 +498,11 @@ def create_c_and_f(a_mag, b_mag, a_inds, a_size, b_inds, b_size, a_b_area, b_b_a
 
         # Also filter the a-catalogue objects for being within our magnitude
         # range, but don't do anything to b, so re-use the previous one.
-        if np.sum(a_b_area > 0) > 0:
+        if np.sum((a_b_area > 0) & a_mag_filter) > 0:
             aba_perc = np.percentile(a_b_area[(a_b_area > 0) & a_mag_filter], pc)
         else:
             aba_perc = np.zeros(len(pc), float)
-        if np.sum(a_f_area > 0) > 0:
+        if np.sum((a_f_area > 0) & a_mag_filter) > 0:
             afa_perc = np.percentile(a_f_area[(a_f_area > 0) & a_mag_filter], pc)
         else:
             afa_perc = np.zeros(len(pc), float)

--- a/tests/macauff/test_group_sources.py
+++ b/tests/macauff/test_group_sources.py
@@ -283,7 +283,7 @@ def test_clean_overlaps():
         inds[:, 8+10*i] = [2, 2, 2, 2, 2]
         inds[:, 9+10*i] = [1, 1, 2, 3, -1]
 
-    inds2, size2, cdf2 = _clean_overlaps(inds, size, inds*10, 2)
+    inds2, size2, cdf2 = _clean_overlaps(inds, size, inds*10, 2, 0)
     compare_inds2 = np.empty((4, 30), int)
     for i in range(0, 3):
         compare_inds2[:, 0+10*i] = [0, 1, -1, -1]


### PR DESCRIPTION
A small PR to fixup a few issues revealed by recent large-scale testing of the latest branch merges:

- stop infinite SNR from breaking scale generation in `AstrometricCorrections`
- filter NaN magnitudes from `AstrometricCorrections` plots 
- fixed issue with `AstrometricCorrections` breaking out in poor-number-statistics instances, and implemented a better catch for these instances that means some useable corrections may be performed
- avoid accidental race condition in `SharedNumpyArray`
- create resilience in `avg_*_areas` in the case that there are no valid areas and hence the average is zero
- sidestep out-of-memory issues with pole-based chunks in `calculate_cf_areas`